### PR TITLE
BomGenerator11: Fix serialization of the "comment" field

### DIFF
--- a/src/main/java/org/cyclonedx/BomGenerator11.java
+++ b/src/main/java/org/cyclonedx/BomGenerator11.java
@@ -170,7 +170,7 @@ public class BomGenerator11 extends AbstractBomGenerator implements BomGenerator
                 if (reference.getType() != null) {
                     final Element referenceNode = createElement(externalReferencesNode, "reference", null, new Attribute("type", reference.getType().getTypeName()));
                     createElement(referenceNode, "url", stripBreaks(reference.getUrl()));
-                    createElement(referenceNode, "comment", stripBreaks(reference.getUrl()));
+                    createElement(referenceNode, "comment", stripBreaks(reference.getComment()));
                 }
             }
         }


### PR DESCRIPTION
Previously, it contained a copy of the "url" field instead.