### PR TITLE
fix npe while loading resources from ext in java 1.8 enviornment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+*.iml

--- a/src/test/java/org/cyclonedx/BomParserTest.java
+++ b/src/test/java/org/cyclonedx/BomParserTest.java
@@ -18,6 +18,7 @@
  */
 package org.cyclonedx;
 
+import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -163,5 +164,12 @@ public class BomParserTest {
         Assert.assertEquals(1, d2.getDependencies().size());
         Assert.assertNull(d3.getDependencies());
 
+    }
+
+    @Test
+    public void testLoadingSchemaFromExt() {
+        final BomParser parser = new BomParser();
+        List<InputStream> streams = parser.loadSchemaFromExtensions("test-ext");
+        Assert.assertEquals(2, streams.size());
     }
 }

--- a/src/test/resources/test-ext/dummy.xsd
+++ b/src/test/resources/test-ext/dummy.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CycloneDX Vulnerability Extension
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:vuln="http://cyclonedx.org/schema/ext/vulnerability/1.0"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/ext/vulnerability/1.0"
+           vc:minVersion="1.0"
+           vc:maxVersion="1.1"
+           version="1.0.0">
+
+
+</xs:schema>

--- a/src/test/resources/test-ext/dummy2.xsd
+++ b/src/test/resources/test-ext/dummy2.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CycloneDX Vulnerability Extension
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:vuln="http://cyclonedx.org/schema/ext/vulnerability/1.0"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/ext/vulnerability/1.0"
+           vc:minVersion="1.0"
+           vc:maxVersion="1.1"
+           version="1.0.0">
+
+
+</xs:schema>


### PR DESCRIPTION
While running `makeAggregateBom` in a java 1.8 environment, due to the nature of resource reading from the `ext` folder from within a jar, the plugin was throwing a NPE due to the invalid stream.

Environment specification for refernce:
`
Maven home: /usr/local/Cellar/maven@3.5/3.5.4/libexec
Java version: 1.8.0_131, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.14.4", arch: "x86_64", family: "mac"`

Exception stack trace:

`Caused by: java.lang.NullPointerException
    at java.io.FilterInputStream.read (FilterInputStream.java:83)
    at org.apache.xerces.impl.XMLEntityManager$RewindableInputStream.readAndBuffer (Unknown Source)
    at org.apache.xerces.impl.XMLEntityManager.setupCurrentEntity (Unknown Source)
    at org.apache.xerces.impl.XMLVersionDetector.determineDocVersion (Unknown Source)
    at org.apache.xerces.impl.xs.opti.SchemaParsingConfig.parse (Unknown Source)
    at org.apache.xerces.impl.xs.opti.SchemaParsingConfig.parse (Unknown Source)
    at org.apache.xerces.impl.xs.opti.SchemaDOMParser.parse (Unknown Source)
    at org.apache.xerces.impl.xs.traversers.XSDHandler.getSchemaDocument (Unknown Source)
    at org.apache.xerces.impl.xs.traversers.XSDHandler.parseSchema (Unknown Source)
    at org.apache.xerces.impl.xs.XMLSchemaLoader.loadSchema (Unknown Source)
    at org.apache.xerces.impl.xs.XMLSchemaLoader.loadGrammar (Unknown Source)
    at org.apache.xerces.impl.xs.XMLSchemaLoader.loadGrammar (Unknown Source)
    at org.apache.xerces.jaxp.validation.XMLSchemaFactory.newSchema (Unknown Source)
    at org.cyclonedx.CycloneDxSchema.getXmlSchema (CycloneDxSchema.java:128)
    at org.cyclonedx.CycloneDxSchema.getXmlSchema11 (CycloneDxSchema.java:119)
    at org.cyclonedx.CycloneDxSchema.getXmlSchema (CycloneDxSchema.java:80)
    at org.cyclonedx.BomParser.validate (BomParser.java:197)
    at org.cyclonedx.BomParser.isValid (BomParser.java:239)
    at org.cyclonedx.maven.BaseCycloneDxMojo.execute (BaseCycloneDxMojo.java:590)
    at org.cyclonedx.maven.CycloneDxAggregateMojo.execute (CycloneDxAggregateMojo.java:73)`

Attached fix has been verified in java 8 and 11 environments and does not throw this exception anymore