### PR TITLE
fix Javadoc build error with jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,27 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven.javadoc.plugin.version}</version>
+                        <configuration>
+                            <javadocExecutable>${java.home}/bin</javadocExecutable>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven.javadoc.plugin.version}</version>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -336,11 +336,8 @@
             </build>
         </profile>
         <profile>
-            <id>mac</id>
+            <id>jdk11plus</id>
             <activation>
-                <os>
-                    <family>mac</family>
-                </os>
                 <jdk>[11,)</jdk>
             </activation>
             <build>


### PR DESCRIPTION
This fix started out as being MacOS specific, but when I tested on Ubuntu 18.04, I saw the same problem. The location of the `javadoc` executable is a bit of a moving target, and in jdk11 it tends to live in the `${java.home}/bin` directory (not `${java.home}/../bin/javadoc`).

When running `mvn clean package`, the error before the fix is like this:

Ubuntu 18.04, and `openjdk version "11.0.9" 2020-10-20`:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:jar (attach-javadocs) on project cyclonedx-core-java: MavenReportException: Error while generating Javadoc: Unable to find javadoc command: The javadoc executable '/usr/lib/jvm/java-11-openjdk-amd64/../bin/javadoc' doesn't exist or is not a file. Verify the <javadocExecutable/> parameter. -> [Help 1]
```

MacOSX, and `openjdk version "11.0.6" 2020-01-14`:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:jar (attach-javadocs) on project cyclonedx-core-java: MavenReportException: Error while generating Javadoc: Unable to find javadoc command: The javadoc executable '/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/../bin/javadoc' doesn't exist or is not a file. Verify the <javadocExecutable/> parameter. -> [Help 1]
```

After the fix, the command `mvn clean package` succeeds on both platforms with jdk11.