### PR TITLE
Drop xerces, maybe, since Jackson has woodstox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,6 @@
             <version>2.12.3</version>
         </dependency>
 
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <version>2.12.1</version>
-        </dependency>
-
         <!-- JSON Schema library -->
 
         <dependency>


### PR DESCRIPTION
It occurred to me tonight that you likely do not need a Xerces impl anymore. Jackson provides woodstox, etc... can use aalto, etc...

I removed xerces and everything seemed to work fine. From what I understand woodstox is more modern. I believe someone can ultimately still use xerces if they want (by excluding woodstox and adding xerces as a dependency). I figured I'd propose this since Jackson provides a default stax impl, etc... now