### PR TITLE
changed when the Property deserializer would be called to 1.4.

### DIFF
--- a/src/main/java/org/cyclonedx/util/PropertyDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/PropertyDeserializer.java
@@ -13,7 +13,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.cyclonedx.model.Property;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -148,7 +150,7 @@ public class PropertyDeserializer extends StdDeserializer<List<Property>> {
 	}
 
 	private boolean isPreleaseDeserializationEnabled() {
-		final String s = System.getProperty("cyclonedx.prerelease.13.properties");
+		final String s = System.getProperty("cyclonedx.prerelease.14.properties");
 		return Boolean.parseBoolean(s);
 	}
 }

--- a/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
@@ -18,6 +18,15 @@
  */
 package org.cyclonedx.parsers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
 import org.apache.commons.io.IOUtils;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Bom;
@@ -30,14 +39,6 @@ import org.cyclonedx.model.Pedigree;
 import org.cyclonedx.model.Service;
 import org.cyclonedx.model.ServiceData;
 import org.junit.jupiter.api.Test;
-import java.io.File;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("deprecation")
 public class XmlParserTest {
@@ -439,7 +440,7 @@ public class XmlParserTest {
         assertEquals("Foo", c1.getProperties().get(0).getName());
         assertNull(c1.getProperties().get(0).getValue());
 
-        System.setProperty("cyclonedx.prerelease.13.properties", "true");
+		System.setProperty("cyclonedx.prerelease.14.properties", "true");
         final Bom bom2 = parser.parse(file);
         Component c2 = bom2.getComponents().get(0);
         assertEquals(2, c2.getProperties().size());


### PR DESCRIPTION
Lockheed's code is using the 1.3 schema.  Thus  we would need this to be 1.4 schema (next release) instead of 1.3.  