### PR TITLE
Add library API document publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-documentation:
+    name: "Build documentation"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+      - name: Build with Maven
+        run: mvn package --file pom.xml
+
+      - name: Deploy documentation
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: target/apidocs

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ the CycloneDX version supported by the target system.
 | 2.x | CycloneDX v1.1 | XML |
 | 1.x | CycloneDX v1.0 | XML |
 
+## Library API Documentation
+
+The library API documentation can be viewed online at [https://cyclonedx.github.io/cyclonedx-core-java](https://cyclonedx.github.io/cyclonedx-core-java).
+
 Copyright & License
 -------------------
 


### PR DESCRIPTION
This is a low effort first cut at publishing the library API documentation to GitHub pages.

This is just using the existing javadoc output generated during `mvn package`.

The documentation is updated and published each time the `master` branch is updated.

A copy can be viewed on my fork https://coderpatros.github.io/cyclonedx-core-java