### PR TITLE
Use JsonNode instead of JsonObject for JSON as an object type things

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Maven Usage
 <dependency>
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-core-java</artifactId>
-    <version>6.0.0</version>
+    <version>7.0.0</version>
 </dependency>
 ```
 
@@ -33,6 +33,7 @@ the CycloneDX version supported by the target system.
 
 | Version | Schema Version | Format(s) |
 | ------- | ----------------- | --------- |
+| 7.x | CycloneDX v1.4 | XML/JSON |
 | 6.x | CycloneDX v1.4 | XML/JSON |
 | 5.x | CycloneDX v1.3 | XML/JSON |
 | 4.x | CycloneDX v1.2 | XML/JSON |

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-core-java</artifactId>
     <packaging>jar</packaging>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>7.0.0</version>
 
     <name>CycloneDX Core (Java)</name>
     <description>The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -180,20 +180,6 @@
             <version>1.0.66</version>
         </dependency>
 
-        <!-- JsonObject supporting libraries -->
-
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
-        </dependency>
-
         <!-- Unit Test -->
 
         <dependency>

--- a/src/main/java/org/cyclonedx/generators/json/AbstractBomJsonGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/json/AbstractBomJsonGenerator.java
@@ -20,7 +20,6 @@ package org.cyclonedx.generators.json;
 
 import java.lang.reflect.Field;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
@@ -39,7 +38,7 @@ import org.cyclonedx.util.mixin.MixInBomReference;
 
 public abstract class AbstractBomJsonGenerator extends CycloneDxSchema implements BomJsonGenerator {
 
-    private final ObjectMapper mapper;
+    protected final ObjectMapper mapper;
 
     private final DefaultPrettyPrinter prettyPrinter;
 

--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
@@ -18,15 +18,14 @@
  */
 package org.cyclonedx.generators.json;
 
-import javax.json.JsonObject;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import org.cyclonedx.CycloneDxSchema;
 
 public interface BomJsonGenerator {
 
     CycloneDxSchema.Version getSchemaVersion();
 
-    JsonObject toJsonObject();
+    JsonNode toJsonNode();
 
     String toJsonString();
 

--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator12.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator12.java
@@ -18,10 +18,8 @@
  */
 package org.cyclonedx.generators.json;
 
-import java.io.StringReader;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
@@ -61,14 +59,12 @@ public class BomJsonGenerator12 extends AbstractBomJsonGenerator implements BomJ
     /**
      * Creates a CycloneDX BOM from a set of Components.
      * @return an JSON Document representing a CycloneDX BoM
-     * @since 5.0.0
+     * @since 7.0.0
      */
-    public JsonObject toJsonObject() {
+    public JsonNode toJsonNode() {
         try {
-            JsonReader reader = Json.createReader(new StringReader(toJson(this.bom, false)));
-
-            return reader.readObject();
-        } catch (GeneratorException e) {
+            return mapper.readTree(toJson(this.bom, false));
+        } catch (GeneratorException | JsonProcessingException e) {
             return null;
         }
     }

--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator13.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator13.java
@@ -18,10 +18,8 @@
  */
 package org.cyclonedx.generators.json;
 
-import java.io.StringReader;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
@@ -61,14 +59,12 @@ public class BomJsonGenerator13 extends AbstractBomJsonGenerator implements BomJ
     /**
      * Creates a CycloneDX BOM from a set of Components.
      * @return an JSON Document representing a CycloneDX BoM
-     * @since 5.0.0
+     * @since 7.0.0
      */
-    public JsonObject toJsonObject() {
+    public JsonNode toJsonNode() {
         try {
-            JsonReader reader = Json.createReader(new StringReader(toJson(this.bom, false)));
-
-            return reader.readObject();
-        } catch (GeneratorException e) {
+            return mapper.readTree(toJson(this.bom, false));
+        } catch (GeneratorException | JsonProcessingException e) {
             return null;
         }
     }

--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator14.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator14.java
@@ -18,13 +18,11 @@
  */
 package org.cyclonedx.generators.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import java.io.StringReader;
 
 /**
  * BomGenerator creates a CycloneDX bill-of-material document from a set of
@@ -60,14 +58,12 @@ public class BomJsonGenerator14 extends AbstractBomJsonGenerator implements BomJ
     /**
      * Creates a CycloneDX BOM from a set of Components.
      * @return an JSON Document representing a CycloneDX BoM
-     * @since 6.0.0
+     * @since 7.0.0
      */
-    public JsonObject toJsonObject() {
+    public JsonNode toJsonNode() {
         try {
-            JsonReader reader = Json.createReader(new StringReader(toJson(this.bom, false)));
-
-            return reader.readObject();
-        } catch (GeneratorException e) {
+            return mapper.readTree(toJson(this.bom, false));
+        } catch (GeneratorException | JsonProcessingException e) {
             return null;
         }
     }

--- a/src/main/java/org/cyclonedx/parsers/JsonParser.java
+++ b/src/main/java/org/cyclonedx/parsers/JsonParser.java
@@ -18,6 +18,7 @@
  */
 package org.cyclonedx.parsers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.ValidationMessage;
 import org.apache.commons.io.FileUtils;
@@ -29,15 +30,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 
 /**
  * JsonParser is responsible for validating and parsing CycloneDX bill-of-material
@@ -162,8 +158,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * @since 3.0.0
      */
     public List<ParseException> validate(final String bomString, final CycloneDxSchema.Version schemaVersion) throws IOException {
-        JsonReader reader = Json.createReader(new StringReader(bomString));
-        return validate(reader.readObject(), schemaVersion);
+        return validate(mapper.readTree(bomString), schemaVersion);
     }
 
     /**
@@ -174,7 +169,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * @throws IOException when errors are encountered
      * @since 3.0.0
      */
-    public List<ParseException> validate(final JsonObject bomJson, final CycloneDxSchema.Version schemaVersion) throws IOException {
+    public List<ParseException> validate(final JsonNode bomJson, final CycloneDxSchema.Version schemaVersion) throws IOException {
         final List<ParseException> exceptions = new ArrayList<>();
         Set<ValidationMessage> errors = getJsonSchema(schemaVersion, mapper).validate(mapper.readTree(bomJson.toString()));
         for (ValidationMessage message: errors) {
@@ -238,5 +233,4 @@ public class JsonParser extends CycloneDxSchema implements Parser {
     public boolean isValid(final InputStream inputStream, final CycloneDxSchema.Version schemaVersion) throws IOException {
         return validate(inputStream, schemaVersion).isEmpty();
     }
-
 }

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -18,13 +18,13 @@
  */
 package org.cyclonedx;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.IOUtils;
 import org.cyclonedx.CycloneDxSchema.Version;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.json.BomJsonGenerator12;
 import org.cyclonedx.generators.json.BomJsonGenerator13;
 import org.cyclonedx.generators.json.BomJsonGenerator14;
-import org.cyclonedx.generators.xml.BomXmlGenerator14;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.XmlParser;
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import javax.json.JsonObject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -74,14 +73,14 @@ public class BomJsonGeneratorTest {
     public void schema12JsonObjectGenerationTest() throws Exception {
         Bom bom = createCommonBom("/bom-1.2.xml");
         BomJsonGenerator generator = BomGeneratorFactory.createJson(Version.VERSION_12, bom);
-        JsonObject obj = generator.toJsonObject();
+        JsonNode obj = generator.toJsonNode();
         assertNotNull(obj);
-        assertEquals("CycloneDX", obj.getString("bomFormat"));
-        assertEquals("1.2", obj.getString("specVersion"));
-        assertEquals("urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", obj.getString("serialNumber"));
-        assertEquals(1, obj.getInt("version"));
-        assertEquals(6, obj.getJsonObject("metadata").size());
-        assertEquals(3, obj.getJsonArray("components").size());
+        assertEquals("CycloneDX", obj.get("bomFormat").asText());
+        assertEquals("1.2", obj.get("specVersion").asText());
+        assertEquals("urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", obj.get("serialNumber").asText());
+        assertEquals(1, obj.get("version").asDouble());
+        assertEquals(6, obj.get("metadata").size());
+        assertEquals(3, obj.get("components").size());
     }
 
     @Test


### PR DESCRIPTION
There are a few reasons to do this:

- javax and glassfish are both licensed as GPLv2 with classpath exception. This actually SHOULD be fine for most usage, but it definitely gives people a fun shot of adrenaline. While I am absolutely a purist, I think that if my goal is that this project gets used by the most people possible, it would be nice to remove the shot of adrenaline that comes along with that license
- the other? Jackson is already here, and JsonNode is AFAIK equivalent, and can be turned into a JsonObject by someone consuming this library

It is my thought that this ships as 7.0.0, that way people who are using 1.4 in 6.0.0 have a minute to switch to the `JsonNode` thing, over the `JsonObject` way.
