### PR TITLE
Checked For Index Out Of Bounds

### DIFF
--- a/src/main/java/org/cyclonedx/BomParserFactory.java
+++ b/src/main/java/org/cyclonedx/BomParserFactory.java
@@ -43,6 +43,10 @@ public class BomParserFactory {
     }
 
     public static Parser createParser(final byte[] bytes) throws ParseException {
+        if(bytes.length < 1) {
+            throw new ParseException("Cannot create parser from empty byte array.");
+        }
+
         if (bytes[0] == 123) {
             return new JsonParser();
         } else if (bytes[0] == 60) {

--- a/src/test/java/org/cyclonedx/BomParserFactoryTest.java
+++ b/src/test/java/org/cyclonedx/BomParserFactoryTest.java
@@ -18,12 +18,14 @@
  */
 package org.cyclonedx;
 
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
 import org.junit.jupiter.api.Test;
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BomParserFactoryTest {
@@ -38,5 +40,13 @@ public class BomParserFactoryTest {
     public void testJSONFactory() throws Exception {
         Parser parser = BomParserFactory.createParser(new File(BomParserFactory.class.getResource("/bom-1.2.json").getFile()));
         assertTrue(parser instanceof JsonParser);
+    }
+
+    @Test()
+    public void testFactoryThrowsParseExceptionWithEmptyData() {
+        byte[] emptyData = new byte[]{};
+        assertThrows(ParseException.class, () ->
+            BomParserFactory.createParser(emptyData)
+        );
     }
 }


### PR DESCRIPTION
It is possible at the moment for a user of ```BomParserFactory.createParser(byte[])``` to throw a IndexOutOfBoundsException if they pass in a empty array.  

I have added in a if statement to check the length of the array so this cannot happen. 