### PR TITLE
fix: add missing Vulnerability.properties types in schema 1.4

### DIFF
--- a/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
+++ b/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
@@ -254,6 +254,8 @@ public class Vulnerability
     this.affects = affects;
   }
 
+  @JacksonXmlElementWrapper(localName = "properties")
+  @JacksonXmlProperty(localName = "property")
   public List<Property> getProperties() {
     return properties;
   }

--- a/src/main/resources/bom-1.4.proto
+++ b/src/main/resources/bom-1.4.proto
@@ -526,6 +526,8 @@ message Vulnerability {
   optional VulnerabilityAnalysis analysis = 16;
   // affects
   repeated VulnerabilityAffects affects = 17;
+  // Specifies optional, custom, properties
+  repeated Property properties = 18;
 }
 
 message VulnerabilityReference {

--- a/src/main/resources/bom-1.4.xsd
+++ b/src/main/resources/bom-1.4.xsd
@@ -2014,6 +2014,16 @@ limitations under the License.
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
         <xs:attribute name="bom-ref" type="bom:refType">
             <xs:annotation>

--- a/src/test/resources/1.4/valid-vulnerability-1.4.json
+++ b/src/test/resources/1.4/valid-vulnerability-1.4.json
@@ -116,6 +116,24 @@
             }
           ]
         }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
       ]
     }
   ]

--- a/src/test/resources/1.4/valid-vulnerability-1.4.textproto
+++ b/src/test/resources/1.4/valid-vulnerability-1.4.textproto
@@ -100,4 +100,20 @@ vulnerabilities {
       status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
     }
   }
+  properties {
+    name: "Foo"
+    value: "Bar"
+  }
+  properties {
+    name: "Foo"
+    value: "You"
+  }
+  properties {
+    name: "Foo"
+    value: "Two"
+  }
+  properties {
+    name: "Bar"
+    value: "Foo"
+  }
 }

--- a/src/test/resources/1.4/valid-vulnerability-1.4.xml
+++ b/src/test/resources/1.4/valid-vulnerability-1.4.xml
@@ -116,6 +116,12 @@
                     </versions>
                 </target>
             </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
         </vulnerability>
     </vulnerabilities>
 </bom>

--- a/src/test/resources/bom-1.4.json
+++ b/src/test/resources/bom-1.4.json
@@ -382,6 +382,24 @@
               }
             ]
         }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
       ]
     }
   ]

--- a/src/test/resources/bom-1.4.xml
+++ b/src/test/resources/bom-1.4.xml
@@ -277,6 +277,12 @@
                     </versions>
                 </target>
             </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
         </vulnerability>
     </vulnerabilities>
 </bom>


### PR DESCRIPTION
https://github.com/CycloneDX/cyclonedx-core-java/blob/6ed3a6894d68cf3a160d0d47e6ba042228837e89/src/test/resources/README.txt#L4-L5

Mirrors https://github.com/CycloneDX/specification/pull/148

Related: https://github.com/CycloneDX/specification/issues/147