### PR TITLE
Add .gitattributes file for cross-platform EOL handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+# This file is used for computing hashes which must not differ by platform
+src/test/resources/hashtest.txt text eol=lf
+
+# Shell scripts must always use LF even on Windows
+*.sh  text eol=lf
+
+# These are explicitly Windows files and should use crlf
+*.bat  text eol=crlf


### PR DESCRIPTION
`mvn verify` failed on Windows using cyclonedx-core-java v7.1.5:

```
[ERROR] Failures:
[ERROR]   BomUtilsTest.calculateHashesTest:51->assertThatHashIsComputed:88 [Invalid hash for MD5 algorithm. check single element]
expected: "5dd39cab1c53c2c77cd352983f9641e1"
 but was: "a4d83b950999f569f7fee8d96fb31900"
[INFO]
[ERROR] Tests run: 548, Failures: 1, Errors: 0, Skipped: 0
```

The reason was that line feed characters differ on Windows (CRLF vs LF), which changes the input file (hashtest.txt).

This PR fixes this problem by adding EOL control via Git. Now line feeds should be fine on any platform. 😄