### PR TITLE
Added alternative LGPL-3.0 url to seeAlso

### DIFF
--- a/src/main/resources/licenses/licenses.json
+++ b/src/main/resources/licenses/licenses.json
@@ -5238,7 +5238,8 @@
       "seeAlso": [
         "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/licenses/LGPL-3.0",
+        "https://www.gnu.org/licenses/lgpl-3.0.html"
       ],
       "isOsiApproved": true
     },


### PR DESCRIPTION
This URL was encountered by the Maven plugin for the library javaparser-core 3.23.x
While the scraped license name is not specific enough for a match ("GNU Lesser General Public License"), the URL iss ufficient for a unique match using the "seeAlso" list.