### PR TITLE
fix: conform Json mime type property to schema

### DIFF
--- a/src/main/java/org/cyclonedx/model/Component.java
+++ b/src/main/java/org/cyclonedx/model/Component.java
@@ -115,6 +115,7 @@ public class Component extends ExtensibleElement {
     @JsonProperty("bom-ref")
     private String bomRef;
     @JacksonXmlProperty(isAttribute = true, localName = "mime-type")
+    @JsonProperty("mime-type")
     private String mimeType;
     @VersionFilter(versions = {"1.2", "1.3", "1.4"})
     private OrganizationalEntity supplier;


### PR DESCRIPTION
Current Json produced by CycloneDX java refers to MIME type property as "mimeType". That contradicts the schema which has it as "mime-type". This PR and commit fixes it.