### PR TITLE
serialize component early in metadata

### DIFF
--- a/src/main/java/org/cyclonedx/model/Metadata.java
+++ b/src/main/java/org/cyclonedx/model/Metadata.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"timestamp", "tools", "authors", "component", "manufacture", "supplier", "licenses", "properties"})
+@JsonPropertyOrder({"timestamp", "component", "manufacture", "supplier", "licenses", "properties", "tools", "authors"})
 public class Metadata extends ExtensibleElement {
 
     @JsonSerialize(using = CustomDateSerializer.class)


### PR DESCRIPTION
tools is too prominent in generated BOMs, when component is much more important
see for example https://repo1.maven.org/maven2/commons-daemon/commons-daemon/1.3.3/commons-daemon-1.3.3-cyclonedx.json