### PR TITLE
add release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,65 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: $NEXT_PATCH_VERSION
+tag-template: cyclonedx-core-java-$NEXT_MINOR_VERSION
+version-template: $MAJOR.$MINOR.$PATCH
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: ":boom: Breaking changes"
+    labels: 
+      - breaking
+  - title: 🚨 Removed
+    label: removed
+  - title: ":tada: Major features and improvements"
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    label: deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+  - title: ":construction_worker: Changes for plugin developers"
+    labels:
+      - developer 
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    label: 
+      - dependencies
+      - dependency
+      - dependency-upgrade
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 👻 Maintenance
+    labels: 
+      - chore
+      - internal
+      - maintenance
+  - title: 🔧 Build
+    label: build           
+  - title: 🚦 Tests
+    labels: 
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
+change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
+
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
equivalent to what has been done in https://github.com/CycloneDX/cyclonedx-maven-plugin/pull/247

easily produces Release Notes like https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.4 by looking at labels put on each PR

can solve most of #203 