### PR TITLE
Add missing Signature model JsonInclude.Include.NON_EMPTY

### DIFF
--- a/src/main/java/org/cyclonedx/model/Signature.java
+++ b/src/main/java/org/cyclonedx/model/Signature.java
@@ -20,6 +20,7 @@ package org.cyclonedx.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * @since 6.0.0
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({
     "signers",


### PR DESCRIPTION
Adds JsonInclude.Include.NON_EMPTY to the Signature model, to prevent "null" or "" property generation.

Fixes: https://github.com/CycloneDX/cyclonedx-core-java/issues/271
