### PR TITLE
Update Version to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ CycloneDX Core (Java)
 =========
 
 The CycloneDX core module provides a model representation of the SBOM along with utilities to assist in creating, 
-validating, and parsing SBOMs. CycloneDX is a lightweight software bill of materials (SBOM) specification designed for 
-use in application security contexts and supply chain component analysis.
+validating, and parsing SBOMs. OWASP CycloneDX is a full-stack Bill of Materials (BOM) standard that provides advanced
+supply chain capabilities for cyber risk reduction
 
 Maven Usage
 -------------------
@@ -21,7 +21,7 @@ Maven Usage
 <dependency>
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-core-java</artifactId>
-    <version>7.3.2</version>
+    <version>8.0.0</version>
 </dependency>
 ```
 
@@ -33,6 +33,7 @@ the CycloneDX version supported by the target system.
 
 | Version | Schema Version | Format(s) |
 |---------|----------------|-----------|
+| 8.x     | CycloneDX v1.5 | XML/JSON  |
 | 7.x     | CycloneDX v1.4 | XML/JSON  |
 | 6.x     | CycloneDX v1.4 | XML/JSON  |
 | 5.x     | CycloneDX v1.3 | XML/JSON  |

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-core-java</artifactId>
     <packaging>jar</packaging>
-    <version>7.4.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
 
     <name>CycloneDX Core (Java)</name>
     <description>The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.</description>


### PR DESCRIPTION
* Update README description...  CycloneDX should no longer be described as lightweight.
* Bumped lastest version to 8.x iin README n order to be consistent with all previous releases that have updated schema version.
* Update version in POM from 7.4.0-SNAPSHOT to 8.0.0-SNAPSHOT

Signed-off-by: Mark Symons <mark.symons@fujitsu.com>