### PR TITLE
Update LicenseResolver.java

### DIFF
--- a/src/main/java/org/cyclonedx/util/LicenseResolver.java
+++ b/src/main/java/org/cyclonedx/util/LicenseResolver.java
@@ -32,6 +32,8 @@ import java.util.List;
 
 public final class LicenseResolver {
 
+    private static LicenseList licenses;
+
     /**
      * Private constructor.
      */
@@ -101,9 +103,11 @@ public final class LicenseResolver {
     private static LicenseChoice resolveLicenseString(String licenseString, LicenseTextSettings licenseTextSettings, final ObjectMapper mapper)
         throws IOException
     {
-        final InputStream is = LicenseResolver.class.getResourceAsStream("/licenses/licenses.json");
+        if (licenses == null) {
+          final InputStream is = LicenseResolver.class.getResourceAsStream("/licenses/licenses.json");
 
-        final LicenseList licenses = mapper.readValue(is, LicenseList.class);
+          licenses = mapper.readValue(is, LicenseList.class);        
+        }
 
         if (licenses != null && licenses.licenses != null && !licenses.licenses.isEmpty()) {
             for (LicenseDetail licenseDetail : licenses.licenses) {


### PR DESCRIPTION
While doing some manual tests using this library I noticed a significant time being spent in `LicenseResolver.java`.. I was testing with ~2000 components and the endpoint I was testing was taking around ~10 seconds. Caching the `licenseList` as I did in this PR reduced the response time to ~5 seconds. Based on my observation a significant time is spent while 1. reading the licenses file and 2. in `mapper.readValue`..  