### PR TITLE
Bump com.networknt:json-schema-validator to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.0.87</version>
+            <version>1.4.0</version>
         </dependency>
 
         <!-- Unit Test -->

--- a/src/main/java/org/cyclonedx/CycloneDxSchema.java
+++ b/src/main/java/org/cyclonedx/CycloneDxSchema.java
@@ -24,6 +24,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.SpecVersionDetector;
+import com.networknt.schema.resource.MapSchemaMapper;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.xml.sax.SAXException;
@@ -128,9 +129,13 @@ public abstract class CycloneDxSchema
         getClass().getClassLoader().getResource("bom-1.4.schema.json").toExternalForm());
     offlineMappings.put("http://cyclonedx.org/schema/bom-1.5.schema.json",
         getClass().getClassLoader().getResource("bom-1.5.schema.json").toExternalForm());
-    config.setUriMappings(offlineMappings);
+
     JsonNode schemaNode = mapper.readTree(spdxInstream);
-    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaNode));
+    final MapSchemaMapper offlineSchemaMapper = new MapSchemaMapper(offlineMappings);
+    JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaNode)))
+      .jsonMapper(mapper)
+      .schemaMappers(s -> s.add(offlineSchemaMapper))
+      .build();
     return factory.getSchema(schemaNode, config);
   }
 

--- a/src/main/java/org/cyclonedx/CycloneDxSchema.java
+++ b/src/main/java/org/cyclonedx/CycloneDxSchema.java
@@ -118,6 +118,8 @@ public abstract class CycloneDxSchema
   {
     final InputStream spdxInstream = getJsonSchemaAsStream(schemaVersion);
     final SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+    config.setPreloadJsonSchema(false);
+
     final Map<String, String> offlineMappings = new HashMap<>();
     offlineMappings.put("http://cyclonedx.org/schema/spdx.schema.json",
         getClass().getClassLoader().getResource("spdx.schema.json").toExternalForm());


### PR DESCRIPTION
https://github.com/CycloneDX/cyclonedx-core-java/blob/a45240713b751d80d53e6298aa832285a4aba566/pom.xml#L186

It would be nice if the dependency to
`com.networknt:json-schema-validator:1.0.73` as found in the pom.xml
could be upgraded to the [latest 1.4.0](https://mvnrepository.com/artifact/com.networknt/json-schema-validator/1.4.0), as one of our projects depends on
features in this latest version and therefore conflicts with the
dependency of this project.

This Pull Request implements the changes needed to use the
latest version of the json schema validator. More
specifically, it uses the new JSON Schema Mapper
format for creating the JsonSchemaFactory instance:

```java
final MapSchemaMapper offlineSchemaMapper = new MapSchemaMapper(offlineMappings);
JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersionDetector.detect(schemaNode)))
  .jsonMapper(mapper)
  .schemaMappers(s -> s.add(offlineSchemaMapper))
  .build();
```

As can be seen in https://github.com/CycloneDX/cyclonedx-core-java/compare/master...YanWittmann:cyclonedx-core-java-bump-validator:master#diff-fc28290f55c35403fc95b45ee2714337621f54b48caba5e01f08d5760b54139a

Also see all the [rejected PRs](https://github.com/CycloneDX/cyclonedx-core-java/pulls?q=is%3Apr+validator+is%3Aclosed) by dependabot to bump the version,
most likely rejected because they introduced that new schema
mapper which breaks the current usage.