### PR TITLE
ToolInformation - Equals, HashCode, and multi-tool parsing fixes w/tests

### DIFF
--- a/src/main/java/org/cyclonedx/model/metadata/ToolInformation.java
+++ b/src/main/java/org/cyclonedx/model/metadata/ToolInformation.java
@@ -1,10 +1,12 @@
 package org.cyclonedx.model.metadata;
 
 import java.util.List;
+import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Service;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ToolInformation
@@ -13,6 +15,7 @@ public class ToolInformation
 
   private List<Service> services;
 
+  
   public List<Component> getComponents() {
     return components;
   }
@@ -21,11 +24,26 @@ public class ToolInformation
     this.components = components;
   }
 
+  
   public List<Service> getServices() {
     return services;
   }
 
   public void setServices(final List<Service> services) {
     this.services = services;
+  }
+  
+  @Override
+  public int hashCode() {
+      return Objects.hash(components, services);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      ToolInformation other = (ToolInformation) o;
+      return Objects.equals(components, other.components) &&
+              Objects.equals(services, other.services);
   }
 }

--- a/src/main/java/org/cyclonedx/model/metadata/ToolInformation.java
+++ b/src/main/java/org/cyclonedx/model/metadata/ToolInformation.java
@@ -3,10 +3,9 @@ package org.cyclonedx.model.metadata;
 import java.util.List;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Service;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ToolInformation
@@ -15,7 +14,6 @@ public class ToolInformation
 
   private List<Service> services;
 
-  
   public List<Component> getComponents() {
     return components;
   }
@@ -24,7 +22,6 @@ public class ToolInformation
     this.components = components;
   }
 
-  
   public List<Service> getServices() {
     return services;
   }
@@ -32,7 +29,7 @@ public class ToolInformation
   public void setServices(final List<Service> services) {
     this.services = services;
   }
-  
+
   @Override
   public int hashCode() {
       return Objects.hash(components, services);

--- a/src/main/java/org/cyclonedx/util/deserializer/MetadataDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/MetadataDeserializer.java
@@ -140,6 +140,13 @@ public class MetadataDeserializer
         List<Component> components = mapper.convertValue(componentsNode, new TypeReference<List<Component>>() {});
         toolInformation.setComponents(components);
       } else if (componentsNode.isObject()) {
+        if (componentsNode.has("component")) {
+          JsonNode componentNode = componentsNode.get("component");
+          if (componentNode.isArray()) {
+            parseComponents(componentNode, toolInformation);
+            return;
+          }
+        }
         Component component = mapper.convertValue(componentsNode, Component.class);
         toolInformation.setComponents(Collections.singletonList(component));
       }
@@ -152,6 +159,13 @@ public class MetadataDeserializer
         List<Service> services = mapper.convertValue(servicesNode, new TypeReference<List<Service>>() {});
         toolInformation.setServices(services);
       } else if (servicesNode.isObject()) {
+        if (servicesNode.has("service")) {
+          JsonNode serviceNode = servicesNode.get("service");
+          if (serviceNode.isArray()) {
+            parseServices(serviceNode, toolInformation);
+            return;
+          }
+        }
         Service service = mapper.convertValue(servicesNode, Service.class);
         toolInformation.setServices(Collections.singletonList(service));
       }

--- a/src/test/resources/1.5/valid-metadata-tools-1.5.json
+++ b/src/test/resources/1.5/valid-metadata-tools-1.5.json
@@ -1,0 +1,67 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "Awesome Vendor",
+          "name": "Awesome Tool",
+          "version": "9.1.2",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+            }
+          ]
+        },
+        {
+          "type": "application",
+          "group": "Awesome Vendor2",
+          "name": "Awesome Tool2",
+          "version": "7.4.0"
+        }
+      ],
+      "services": [
+        {
+          "provider": {
+            "name": "Acme Org",
+            "url": [
+              "https://example.com"
+            ]
+          },
+          "group": "com.example",
+          "name": "Acme Signing Server",
+          "description": "Signs artifacts",
+          "endpoints": [
+            "https://example.com/sign",
+            "https://example.com/verify",
+            "https://example.com/tsa"
+          ]
+        },
+        {
+          "provider": {
+            "name": "Example Org",
+            "url": [
+              "https://example.com"
+            ]
+          },
+          "group": "com.example",
+          "name": "Some service",
+          "description": "Provides services",
+          "endpoints": [
+            "https://example.com/whatever"
+          ]
+        }
+      ]
+    }
+  },
+  "components": []
+}

--- a/src/test/resources/1.5/valid-metadata-tools-1.5.xml
+++ b/src/test/resources/1.5/valid-metadata-tools-1.5.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+    <metadata>
+        <tools>
+            <components>
+                <component type="application">
+                    <group>Awesome Vendor</group>
+                    <name>Awesome Tool</name>
+                    <version>9.1.2</version>
+                    <hashes>
+                        <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
+                        <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
+                    </hashes>
+                </component>
+                <component type="application">
+                    <group>Awesome Vendor2</group>
+                    <name>Awesome Tool2</name>
+                    <version>7.4.0</version>
+                </component>
+            </components>
+            <services>
+                <service>
+                    <provider>
+                        <name>Acme Org</name>
+                        <url>https://example.com</url>
+                    </provider>
+                    <group>com.example</group>
+                    <name>Acme Signing Server</name>
+                    <description>Signs artifacts</description>
+                    <endpoints>
+                        <endpoint>https://example.com/sign</endpoint>
+                        <endpoint>https://example.com/verify</endpoint>
+                        <endpoint>https://example.com/tsa</endpoint>
+                    </endpoints>
+                </service>
+                <service>
+                    <provider>
+                        <name>Example Org</name>
+                        <url>https://example.com</url>
+                    </provider>
+                    <group>com.example</group>
+                    <name>Some service</name>
+                    <description>Provides services</description>
+                    <endpoints>
+                        <endpoint>https://example.com/whatever</endpoint>
+                    </endpoints>
+                </service>
+            </services>
+        </tools>
+    </metadata>
+    <components />
+</bom>


### PR DESCRIPTION
1. The new ToolInformation class did not have equals & hashCode methods, which prevented equality checks during downstream unit testing
2. The custom deserializer for ToolInformation did not correctly handle multiple components & services, in XML format due to the way jackson nests the nodes