### PR TITLE
Add Mapping for "Mozilla Public License, Version 2.0"

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -257,7 +257,7 @@
   {
     "exp": "MPL-2.0",
     "names": [
-      "MPL 2.0"
+      "MPL 2.0",
       "Mozilla Public License, Version 2.0"
     ]
   },

--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -258,6 +258,7 @@
     "exp": "MPL-2.0",
     "names": [
       "MPL 2.0"
+      "Mozilla Public License, Version 2.0"
     ]
   },
   {


### PR DESCRIPTION
Add "Mozilla Public License, Version 2.0" as mapping to MPL-2.0

Evidence of correct mapping:   `pkg:maven/org.mozilla/rhino@1.7.14`  [Link to POM](https://repo1.maven.org/maven2/org/mozilla/rhino/1.7.14/rhino-1.7.14.pom)

This is published by The Mozilla Foundation themselves.

Signed-off-by: Mark Symons <mark.symons@fujitsu.com>