### PR TITLE
CI pipeline improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,65 +2,39 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches:
+    - master
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+    - master
   schedule:
-    - cron: '0 9 * * 5'
+  - cron: '0 9 * * 5'
+
+permissions: { }
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['java']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
-
+    permissions:
+      security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@23acc5c183826b7a8a97bce3cecc52db901f8251 # tag=v3.25.10
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
+        languages: java
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
+      uses: github/codeql-action/autobuild@23acc5c183826b7a8a97bce3cecc52db901f8251 # tag=v3.25.10
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@23acc5c183826b7a8a97bce3cecc52db901f8251 # tag=v3.25.10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,24 +6,26 @@ on:
       - master
   workflow_dispatch:
 
+permissions: { }
+
 jobs:
   build-documentation:
     name: "Build documentation"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push commits to gh-pages branch
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # tag=v4.2.1
         with:
           distribution: temurin
           java-version: 8
       - name: Build with Maven
-        run: mvn package --file pom.xml
-
+        run: mvn -B --no-transfer-progress package
       - name: Deploy documentation
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # tag=v4.6.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: target/apidocs
+          branch: gh-pages
+          folder: target/apidocs

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,22 +1,47 @@
 name: Maven CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+permissions: { }
 
 jobs:
-  build:
+  test:
+    name: Test
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
-        java-version: [ 8 ]
-        distro: [ 'zulu', 'temurin' ]
-    runs-on: ${{ matrix.os }}
-
+        java-version: [ 8, 11, 17, 21 ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4.1.7
+    - name: Checkout Repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # tag=v4.2.1
       with:
-        distribution: ${{ matrix.distro }}
+        distribution: temurin
         java-version: ${{ matrix.java-version }}
-    - name: Build with Maven
-      run: mvn package --file pom.xml
+        cache: maven
+    - name: Test
+      run: mvn -B --no-transfer-progress clean verify
+    # Publishing coverage to Codacy is only possible for builds of push events.
+    # PRs from forks do not get access to repository secrets.
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    - name: Publish test coverage
+      if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'CycloneDX' && matrix.java-version == '21' }}
+      uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # tag=v1.3.0
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        language: Java
+        coverage-reports: target/site/jacoco/jacoco.xml
+    - name: Upload PR test coverage report
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # tag=v4.3.3
+      with:
+        name: pr-test-coverage-report-java-${{ matrix.java-version }}
+        path: target/site/jacoco/jacoco.xml

--- a/.github/workflows/pr-test-coverage.yml
+++ b/.github/workflows/pr-test-coverage.yml
@@ -1,0 +1,32 @@
+name: Report PR Test Coverage
+
+on:
+  workflow_run:
+    workflows:
+    - Maven CI
+    types:
+    - completed
+
+permissions: { }
+
+jobs:
+  publish:
+    name: Report Coverage
+    runs-on: ubuntu-latest
+    if: |-
+      github.event.workflow_run.event == 'pull_request'
+        && github.event.workflow_run.conclusion == 'success'
+    steps:
+    - name: Download PR test coverage report
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # tag=v4.1.7
+      with:
+        name: pr-test-coverage-report-java-21
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+    - name: Report Coverage to Codacy
+      run: |-
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+          --project-token ${{ secrets.CODACY_PROJECT_TOKEN }} \
+          --commit-uuid ${{ github.event.workflow_run.head_sha }} \
+          --coverage-reports ./target/site/jacoco/jacoco.xml \
+          --language Java

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,11 @@
 name: Release Drafter
+
 on:
   push:
     branches:
-      - master
+    - master
 
-permissions:
-  contents: read
+permissions: { }
 
 jobs:
   update_release_draft:
@@ -14,6 +14,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # tag=v6.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${maven.cyclonedx.plugin.version}</version>


### PR DESCRIPTION
* Only build against Temurin, drop Zulu
* Build against Java 8, 11, 17, and 21, instead of just 8
* Pin 3rd party actions to their digest
* Drop `permissions` on workflow-level, define them on job-level
* Update `JamesIves/github-pages-deploy-action` to the latest version
* Update `release-drafter/release-drafter` to the latest version
* Run the `Maven CI` workflow only for pushes to, or pull request into, `master`. Previously we had duplicate runs for PRs.
* Reduce build output noise by disabling Maven's transfer progress logs
* Record test coverage with JaCoCo
* Publish coverage reports to Codacy
  * Because we build against multiple Java versions, we'll upload only the report generated from the latest Java build