### PR TITLE
External References and Metadata Validations

### DIFF
--- a/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
@@ -6,6 +6,7 @@ import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.util.serializer.EvidenceSerializer;
+import org.cyclonedx.util.serializer.ExternalReferenceSerializer;
 import org.cyclonedx.util.serializer.InputTypeSerializer;
 import org.cyclonedx.util.serializer.LicenseChoiceSerializer;
 import org.cyclonedx.util.serializer.LifecycleSerializer;
@@ -63,5 +64,9 @@ public abstract class AbstractBomGenerator extends CycloneDxSchema
     SimpleModule signatoryModule = new SimpleModule();
     signatoryModule.addSerializer(new SignatorySerializer(isXml));
     mapper.registerModule(signatoryModule);
+
+    SimpleModule externalSerializer = new SimpleModule();
+    externalSerializer.addSerializer(new ExternalReferenceSerializer(getSchemaVersion()));
+    mapper.registerModule(externalSerializer);
   }
 }

--- a/src/main/java/org/cyclonedx/model/Bom.java
+++ b/src/main/java/org/cyclonedx/model/Bom.java
@@ -100,7 +100,7 @@ public class Bom extends ExtensibleElement {
     @VersionFilter(Version.VERSION_15)
     private List<Annotation> annotations;
 
-    @VersionFilter(Version.VERSION_13)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Property> properties;
 
     @JacksonXmlProperty(isAttribute = true)
@@ -241,6 +241,7 @@ public class Bom extends ExtensibleElement {
     @JacksonXmlElementWrapper(localName = "properties")
     @JacksonXmlProperty(localName = "property")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @VersionFilter(Version.VERSION_13)
     public List<Property> getProperties() {
         return properties;
     }

--- a/src/main/java/org/cyclonedx/model/Component.java
+++ b/src/main/java/org/cyclonedx/model/Component.java
@@ -412,6 +412,7 @@ public class Component extends ExtensibleElement {
     @JacksonXmlElementWrapper(localName = "externalReferences")
     @JacksonXmlProperty(localName = "reference")
     @JsonDeserialize(using = ExternalReferencesDeserializer.class)
+    @VersionFilter(Version.VERSION_11)
     public List<ExternalReference> getExternalReferences() {
         return externalReferences;
     }

--- a/src/main/java/org/cyclonedx/model/ExternalReference.java
+++ b/src/main/java/org/cyclonedx/model/ExternalReference.java
@@ -25,16 +25,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.cyclonedx.Version;
-import org.cyclonedx.util.serializer.ExternalReferenceSerializer;
 
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonSerialize(using = ExternalReferenceSerializer.class)
 @JsonPropertyOrder({"url", "comment", "hashes"})
 public class ExternalReference {
 


### PR DESCRIPTION
This adds validation for serializer when creating SBOMs for external reference and metadata that values that are not present in the spec, this excludes them so the generated file is not invalid and it's compliant with the spec.

This is an improvement for the tests to test backward compatibility, and a smaller PR so it's easier to review