### PR TITLE
Fix path to `jacoco.xml` for PR coverage reporting

### DIFF
--- a/.github/workflows/pr-test-coverage.yml
+++ b/.github/workflows/pr-test-coverage.yml
@@ -28,5 +28,5 @@ jobs:
         bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
           --project-token ${{ secrets.CODACY_PROJECT_TOKEN }} \
           --commit-uuid ${{ github.event.workflow_run.head_sha }} \
-          --coverage-reports ./target/site/jacoco/jacoco.xml \
+          --coverage-reports ./jacoco.xml \
           --language Java


### PR DESCRIPTION
The `jacoco.xml` file is saved without directory structure in the workflow artifact, see for example: https://github.com/CycloneDX/cyclonedx-core-java/actions/runs/9569238922/artifacts/1613827643

The *Report Coverage* workflow currently assumes a nested directory structure, causing it to fail: https://github.com/CycloneDX/cyclonedx-core-java/actions/runs/9569252308/job/26381373192