### PR TITLE
Fix possible XXE during XML schema version detection

### DIFF
--- a/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
@@ -19,6 +19,7 @@
 package org.cyclonedx;
 
 import org.apache.commons.io.IOUtils;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.*;
@@ -531,6 +532,13 @@ public class BomXmlGeneratorTest {
 
         XmlParser parser = new XmlParser();
         assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void testXxeProtection() {
+        assertThrows(ParseException.class, () -> {
+            createCommonBomXml("/security/xxe-protection.xml");
+        });
     }
 
     @Test

--- a/src/test/resources/security/xxe-protection.xml
+++ b/src/test/resources/security/xxe-protection.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE bom [<!ENTITY % sp SYSTEM "https://localhost:1010/test/593ab443b77890d052e55899b16b61a8/raw/3cdd376bba0007145fa2bbacb9abe36cbd5a43ce/file.dtd"> %sp; %param1; %exfil;]>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79">
+    <components>
+        <component type="application">
+            <name>Example Application &#x26;xxe;3</name>
+            <version>2.1.0</version>
+            <description>This is an example application</description>
+            <licenses>
+                <license>
+                    <id>Apache-2.0</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/example-app@2.1.0</purl>
+        </component>
+        <component type="library">
+            <name>Example Library</name>
+            <version>3.2.1</version>
+            <licenses>
+                <license>
+                    <id>MIT</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/example-lib@3.2.1</purl>
+        </component>
+    </components>
+</bom>


### PR DESCRIPTION
During some testing, it was found that the parser for XML was vulnerable to XML External Entity (XXE) Processing.

After further investigation from Sonatype team, it was found it was due to the XPath Processing done to get the schema version