### PR TITLE
Update vulnerabilities to use new Tool specification 

### DIFF
--- a/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
+++ b/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
@@ -34,6 +34,7 @@ import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.Tool;
 import org.cyclonedx.model.VersionFilter;
+import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.util.serializer.CustomDateSerializer;
 
 /**
@@ -94,6 +95,10 @@ public class Vulnerability
   @JacksonXmlElementWrapper(localName = "tools")
   @JacksonXmlProperty(localName = "tool")
   private List<Tool> tools;
+  @JacksonXmlElementWrapper(localName = "tools")
+  @JacksonXmlProperty(localName = "tool")
+  @VersionFilter(org.cyclonedx.Version.VERSION_15)
+  private ToolInformation toolInformation;
   private Analysis analysis;
   private List<Affect> affects;
   private List<Property> properties;
@@ -246,6 +251,14 @@ public class Vulnerability
 
   public void setTools(final List<Tool> tools) {
     this.tools = tools;
+  }
+
+  public ToolInformation getToolChoice() {
+    return toolInformation;
+  }
+
+  public void setToolChoice(final ToolInformation toolInformation) {
+    this.toolInformation = toolInformation;
   }
 
   public Analysis getAnalysis() {

--- a/src/test/resources/1.5/valid-vulnerability-tool-1.5.json
+++ b/src/test/resources/1.5/valid-vulnerability-tool-1.5.json
@@ -1,0 +1,154 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.9.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "6eee14da-8f42-4cc4-bb65-203235f02415",
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111",
+      "source": {
+        "name": "Snyk",
+        "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+      },
+      "references": [
+        {
+          "id": "CVE-2018-7489",
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+          }
+        }
+      ],
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+          },
+          "score": 9.8,
+          "severity": "critical",
+          "method": "CVSSv3",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "justification": "An optional reason for rating the vulnerability as it was"
+        }
+      ],
+      "cwes": [
+        184,
+        502
+      ],
+      "description": "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.",
+      "detail": "",
+      "recommendation": "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.",
+      "advisories": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/1931"
+        }
+      ],
+      "created": "2021-01-01T00:00:00.000Z",
+      "published": "2021-01-01T00:00:00.000Z",
+      "updated": "2021-01-01T00:00:00.000Z",
+      "credits": {
+        "organizations": [
+          {
+            "name": "Acme, Inc.",
+            "url": [
+              "https://example.com"
+            ]
+          }
+        ],
+        "individuals": [
+          {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com"
+          }
+        ]
+      },
+      "tools": {
+        "components": [
+          {
+            "type": "application",
+            "group": "Snyk",
+            "name": "Snyk CLI (Linux)",
+            "version": "1.729.0",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "provider": {
+              "name": "Acme Inc"
+            },
+            "name": "Acme BOM Analyzer",
+            "endpoints": [
+              "https://example.com/analyze"
+            ]
+          }
+        ]
+      },
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": ["will_not_fix", "update"],
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component."
+      },
+      "affects": [
+        {
+          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+          "versions": [
+            {
+              "range": "vers:semver/<2.6.7.5",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.7.0|<2.8.11.1",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.9.0|<2.9.5",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/1.5/valid-vulnerability-tool-1.5.textproto
+++ b/src/test/resources/1.5/valid-vulnerability-tool-1.5.textproto
@@ -1,0 +1,137 @@
+spec_version: "1.5"
+version: 1
+serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+components {
+  type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+  group: "com.fasterxml.jackson.core"
+  name: "jackson-databind"
+  version: "2.9.4"
+  purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+}
+vulnerabilities {
+  bom_ref: "6eee14da-8f42-4cc4-bb65-203235f02415"
+  id: "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  source: {
+    name: "Snyk"
+    url: "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  }
+  references: {
+    id: "CVE-2018-7489"
+    source: {
+      name: "NVD",
+      url: "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+    }
+  }
+  ratings: {
+    source: {
+      name: "NVD"
+      url: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+    }
+    score: 9.8
+    severity: SEVERITY_CRITICAL
+    method: SCORE_METHOD_CVSSV3
+    vector: "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    justification: "An optional reason for rating the vulnerability as it was"
+  }
+  cwes: 184
+  cwes: 502
+  description: "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath."
+  detail: ""
+  recommendation:  "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher."
+  advisories: {
+    title: "GitHub Commit"
+    url: "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+  }
+  advisories: {
+    title: "GitHub Issue"
+    url: "https://github.com/FasterXML/jackson-databind/issues/1931"
+  }
+  created: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  published: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  updated: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  credits: {
+    organizations: {
+      name: "Acme, Inc."
+      url: "https://example.com"
+    }
+    individuals: {
+      name: "Jane Doe"
+      email: "jane.doe@example.com"
+    }
+  }
+  tools: {
+    components: [
+      {
+        type: CLASSIFICATION_APPLICATION,
+        group: "Snyk",
+        name: "Snyk CLI (Linux)",
+        version: "1.729.0",
+        hashes: [
+          {
+            alg: HASH_ALG_SHA_256
+            value: "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+          }
+        ]
+      }
+    ]
+    services: [
+      {
+        provider: {
+          name: "Acme Inc"
+        },
+        name: "Acme BOM Analyzer",
+        endpoints: [
+          "https://example.com/analyze"
+        ]
+      }
+    ]
+  }
+  analysis: {
+    state: IMPACT_ANALYSIS_STATE_NOT_AFFECTED
+    justification: IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_REACHABLE
+    response: VULNERABILITY_RESPONSE_WILL_NOT_FIX
+    response: VULNERABILITY_RESPONSE_UPDATE
+    detail: "An optional explanation of why the application is not affected by the vulnerable component."
+  }
+  affects: {
+    ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    versions: {
+      range: "vers:semver/<2.6.7.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.7.0|<2.8.11.1"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.9.0|<2.9.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+  }
+  properties {
+    name: "Foo"
+    value: "Bar"
+  }
+  properties {
+    name: "Foo"
+    value: "You"
+  }
+  properties {
+    name: "Foo"
+    value: "Two"
+  }
+  properties {
+    name: "Bar"
+    value: "Foo"
+  }
+}

--- a/src/test/resources/1.5/valid-vulnerability-tool-1.5.xml
+++ b/src/test/resources/1.5/valid-vulnerability-tool-1.5.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+    <components>
+        <component type="library" bom-ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4">
+            <group>com.fasterxml.jackson.core</group>
+            <name>jackson-databind</name>
+            <version>2.9.4</version>
+            <purl>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</purl>
+        </component>
+    </components>
+    <vulnerabilities>
+        <vulnerability bom-ref="6eee14da-8f42-4cc4-bb65-203235f02415">
+            <id>SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</id>
+            <source>
+                <name>Snyk</name>
+                <url>https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</url>
+            </source>
+            <references>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+            </references>
+            <ratings>
+                <rating>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&amp;version=3.0</url>
+                    </source>
+                    <score>9.8</score>
+                    <severity>critical</severity>
+                    <method>CVSSv3</method>
+                    <vector>AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</vector>
+                    <justification>An optional reason for rating the vulnerability as it was</justification>
+                </rating>
+            </ratings>
+            <cwes>
+                <cwe>184</cwe>
+                <cwe>502</cwe>
+            </cwes>
+            <description>FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.</description>
+            <detail></detail>
+            <recommendation>Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.</recommendation>
+            <advisories>
+                <advisory>
+                    <title>GitHub Commit</title>
+                    <url>https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2</url>
+                </advisory>
+                <advisory>
+                    <title>GitHub Issue</title>
+                    <url>https://github.com/FasterXML/jackson-databind/issues/1931</url>
+                </advisory>
+            </advisories>
+            <created>2021-01-01T00:00:00.000Z</created>
+            <published>2021-01-01T00:00:00.000Z</published>
+            <updated>2021-01-01T00:00:00.000Z</updated>
+            <credits>
+                <organizations>
+                    <organization>
+                        <name>Acme, Inc.</name>
+                        <url>https://example.com</url>
+                    </organization>
+                </organizations>
+                <individuals>
+                    <individual>
+                        <name>Jane Doe</name>
+                        <email>jane.doe@example.com</email>
+                    </individual>
+                </individuals>
+            </credits>
+            <tools>
+                <components>
+                    <component type="application">
+                        <group>Snyk</group>
+                        <name>Snyk CLI (Linux)</name>
+                        <version>1.729.0</version>
+                        <hashes>
+                            <hash alg="SHA-256">2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d</hash>
+                        </hashes>
+                    </component>
+                </components>
+                <services>
+                    <service>
+                        <provider>
+                            <name>Acme Inf</name>
+                        </provider>
+                        <name>Acme BOM Analyzer</name>
+                        <endpoints>
+                            <endpoint>https://example.com/analyze</endpoint>
+                        </endpoints>
+                    </service>
+                </services>
+            </tools>
+            <analysis>
+                <state>not_affected</state>
+                <justification>code_not_reachable</justification>
+                <responses>
+                    <response>will_not_fix</response>
+                    <response>update</response>
+                </responses>
+                <detail>An optional explanation of why the application is not affected by the vulnerable component.</detail>
+            </analysis>
+            <affects>
+                <target>
+                    <ref>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</ref>
+                    <versions>
+                        <version>
+                            <range>vers:semver/&lt;2.6.7.5</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.7.0|&lt;2.8.11.1</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.9.0|&lt;2.9.5</range>
+                            <status>affected</status>
+                        </version>
+                    </versions>
+                </target>
+            </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
+        </vulnerability>
+    </vulnerabilities>
+</bom>

--- a/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.json
+++ b/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.json
@@ -1,0 +1,140 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.9.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "6eee14da-8f42-4cc4-bb65-203235f02415",
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111",
+      "source": {
+        "name": "Snyk",
+        "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+      },
+      "references": [
+        {
+          "id": "CVE-2018-7489",
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+          }
+        }
+      ],
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+          },
+          "score": 9.8,
+          "severity": "critical",
+          "method": "CVSSv3",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "justification": "An optional reason for rating the vulnerability as it was"
+        }
+      ],
+      "cwes": [
+        184,
+        502
+      ],
+      "description": "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.",
+      "detail": "",
+      "recommendation": "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.",
+      "advisories": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/1931"
+        }
+      ],
+      "created": "2021-01-01T00:00:00.000Z",
+      "published": "2021-01-01T00:00:00.000Z",
+      "updated": "2021-01-01T00:00:00.000Z",
+      "credits": {
+        "organizations": [
+          {
+            "name": "Acme, Inc.",
+            "url": [
+              "https://example.com"
+            ]
+          }
+        ],
+        "individuals": [
+          {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com"
+          }
+        ]
+      },
+      "tools": [
+        {
+          "vendor": "Snyk",
+          "name": "Snyk CLI (Linux)",
+          "version": "1.729.0",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": ["will_not_fix", "update"],
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component."
+      },
+      "affects": [
+        {
+          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+          "versions": [
+            {
+              "range": "vers:semver/<2.6.7.5",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.7.0|<2.8.11.1",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.9.0|<2.9.5",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.textproto
+++ b/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.textproto
@@ -1,0 +1,119 @@
+spec_version: "1.5"
+version: 1
+serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+components {
+  type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+  group: "com.fasterxml.jackson.core"
+  name: "jackson-databind"
+  version: "2.9.4"
+  purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+}
+vulnerabilities {
+  bom_ref: "6eee14da-8f42-4cc4-bb65-203235f02415"
+  id: "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  source: {
+    name: "Snyk"
+    url: "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  }
+  references: {
+    id: "CVE-2018-7489"
+    source: {
+      name: "NVD",
+      url: "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+    }
+  }
+  ratings: {
+    source: {
+      name: "NVD"
+      url: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+    }
+    score: 9.8
+    severity: SEVERITY_CRITICAL
+    method: SCORE_METHOD_CVSSV3
+    vector: "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    justification: "An optional reason for rating the vulnerability as it was"
+  }
+  cwes: 184
+  cwes: 502
+  description: "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath."
+  detail: ""
+  recommendation:  "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher."
+  advisories: {
+    title: "GitHub Commit"
+    url: "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+  }
+  advisories: {
+    title: "GitHub Issue"
+    url: "https://github.com/FasterXML/jackson-databind/issues/1931"
+  }
+  created: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  published: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  updated: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  credits: {
+    organizations: {
+      name: "Acme, Inc."
+      url: "https://example.com"
+    }
+    individuals: {
+      name: "Jane Doe"
+      email: "jane.doe@example.com"
+    }
+  }
+  tools: {
+    vendor: "Snyk"
+    name: "Snyk CLI (Linux)"
+    version: "1.729.0"
+    hashes: {
+      alg: HASH_ALG_SHA_256
+      value: "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+    }
+  }
+  analysis: {
+    state: IMPACT_ANALYSIS_STATE_NOT_AFFECTED
+    justification: IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_REACHABLE
+    response: VULNERABILITY_RESPONSE_WILL_NOT_FIX
+    response: VULNERABILITY_RESPONSE_UPDATE
+    detail: "An optional explanation of why the application is not affected by the vulnerable component."
+  }
+  affects: {
+    ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    versions: {
+      range: "vers:semver/<2.6.7.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.7.0|<2.8.11.1"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.9.0|<2.9.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+  }
+  properties {
+    name: "Foo"
+    value: "Bar"
+  }
+  properties {
+    name: "Foo"
+    value: "You"
+  }
+  properties {
+    name: "Foo"
+    value: "Two"
+  }
+  properties {
+    name: "Bar"
+    value: "Foo"
+  }
+}

--- a/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.xml
+++ b/src/test/resources/1.5/valid-vulnerability-tool-deprecated-1.5.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+    <components>
+        <component type="library" bom-ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4">
+            <group>com.fasterxml.jackson.core</group>
+            <name>jackson-databind</name>
+            <version>2.9.4</version>
+            <purl>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</purl>
+        </component>
+    </components>
+    <vulnerabilities>
+        <vulnerability bom-ref="6eee14da-8f42-4cc4-bb65-203235f02415">
+            <id>SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</id>
+            <source>
+                <name>Snyk</name>
+                <url>https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</url>
+            </source>
+            <references>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+            </references>
+            <ratings>
+                <rating>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&amp;version=3.0</url>
+                    </source>
+                    <score>9.8</score>
+                    <severity>critical</severity>
+                    <method>CVSSv3</method>
+                    <vector>AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</vector>
+                    <justification>An optional reason for rating the vulnerability as it was</justification>
+                </rating>
+            </ratings>
+            <cwes>
+                <cwe>184</cwe>
+                <cwe>502</cwe>
+            </cwes>
+            <description>FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.</description>
+            <detail></detail>
+            <recommendation>Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.</recommendation>
+            <advisories>
+                <advisory>
+                    <title>GitHub Commit</title>
+                    <url>https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2</url>
+                </advisory>
+                <advisory>
+                    <title>GitHub Issue</title>
+                    <url>https://github.com/FasterXML/jackson-databind/issues/1931</url>
+                </advisory>
+            </advisories>
+            <created>2021-01-01T00:00:00.000Z</created>
+            <published>2021-01-01T00:00:00.000Z</published>
+            <updated>2021-01-01T00:00:00.000Z</updated>
+            <credits>
+                <organizations>
+                    <organization>
+                        <name>Acme, Inc.</name>
+                        <url>https://example.com</url>
+                    </organization>
+                </organizations>
+                <individuals>
+                    <individual>
+                        <name>Jane Doe</name>
+                        <email>jane.doe@example.com</email>
+                    </individual>
+                </individuals>
+            </credits>
+            <tools>
+                <tool>
+                    <vendor>Snyk</vendor>
+                    <name>Snyk CLI (Linux)</name>
+                    <version>1.729.0</version>
+                    <hashes>
+                        <hash alg="SHA-256">2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d</hash>
+                    </hashes>
+                </tool>
+            </tools>
+            <analysis>
+                <state>not_affected</state>
+                <justification>code_not_reachable</justification>
+                <responses>
+                    <response>will_not_fix</response>
+                    <response>update</response>
+                </responses>
+                <detail>An optional explanation of why the application is not affected by the vulnerable component.</detail>
+            </analysis>
+            <affects>
+                <target>
+                    <ref>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</ref>
+                    <versions>
+                        <version>
+                            <range>vers:semver/&lt;2.6.7.5</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.7.0|&lt;2.8.11.1</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.9.0|&lt;2.9.5</range>
+                            <status>affected</status>
+                        </version>
+                    </versions>
+                </target>
+            </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
+        </vulnerability>
+    </vulnerabilities>
+</bom>

--- a/src/test/resources/1.6/valid-vulnerability-tool-1.6.json
+++ b/src/test/resources/1.6/valid-vulnerability-tool-1.6.json
@@ -1,0 +1,169 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.9.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "6eee14da-8f42-4cc4-bb65-203235f02415",
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111",
+      "source": {
+        "name": "Snyk",
+        "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+      },
+      "references": [
+        {
+          "id": "CVE-2018-7489",
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+          }
+        }
+      ],
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+          },
+          "score": 9.8,
+          "severity": "critical",
+          "method": "CVSSv3",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "justification": "An optional reason for rating the vulnerability as it was"
+        }
+      ],
+      "cwes": [
+        184,
+        502
+      ],
+      "description": "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.",
+      "detail": "",
+      "recommendation": "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.",
+      "workaround": "Describe the workarounds here",
+      "proofOfConcept": {
+        "reproductionSteps": "Precise steps to reproduce go here",
+        "environment": "Describe the environment",
+        "supportingMaterial": [
+          {
+            "contentType": "image/jpeg",
+            "encoding": "base64",
+            "content": "/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k="
+          }
+        ]
+      },
+      "advisories": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/1931"
+        }
+      ],
+      "created": "2021-01-01T00:00:00.000Z",
+      "published": "2021-01-01T00:00:00.000Z",
+      "updated": "2021-01-01T00:00:00.000Z",
+      "rejected": "2022-01-01T00:00:00.000Z",
+      "credits": {
+        "organizations": [
+          {
+            "name": "Acme, Inc.",
+            "url": [
+              "https://example.com"
+            ]
+          }
+        ],
+        "individuals": [
+          {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com"
+          }
+        ]
+      },
+      "tools": {
+        "components": [
+          {
+            "type": "application",
+            "group": "Snyk",
+            "name": "Snyk CLI (Linux)",
+            "version": "1.729.0",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "provider": {
+              "name": "Acme Inc"
+            },
+            "name": "Acme BOM Analyzer",
+            "endpoints": [
+              "https://example.com/analyze"
+            ]
+          }
+        ]
+      },
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": ["will_not_fix", "update"],
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component.",
+        "firstIssued": "2022-01-01T00:00:00.000Z",
+        "lastUpdated": "2022-02-01T00:00:00.000Z"
+      },
+      "affects": [
+        {
+          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+          "versions": [
+            {
+              "range": "vers:semver/<2.6.7.5",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.7.0|<2.8.11.1",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.9.0|<2.9.5",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/1.6/valid-vulnerability-tool-1.6.textproto
+++ b/src/test/resources/1.6/valid-vulnerability-tool-1.6.textproto
@@ -1,0 +1,164 @@
+# proto-file: schema/bom-1.6.proto
+# proto-message: Bom
+
+spec_version: "1.6"
+version: 1
+serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+components {
+  type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+  group: "com.fasterxml.jackson.core"
+  name: "jackson-databind"
+  version: "2.9.4"
+  purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+}
+vulnerabilities {
+  bom_ref: "6eee14da-8f42-4cc4-bb65-203235f02415"
+  id: "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  source: {
+    name: "Snyk"
+    url: "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  }
+  references: {
+    id: "CVE-2018-7489"
+    source: {
+      name: "NVD",
+      url: "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+    }
+  }
+  ratings: {
+    source: {
+      name: "NVD"
+      url: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+    }
+    score: 9.8
+    severity: SEVERITY_CRITICAL
+    method: SCORE_METHOD_CVSSV3
+    vector: "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    justification: "An optional reason for rating the vulnerability as it was"
+  }
+  cwes: 184
+  cwes: 502
+  description: "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath."
+  detail: ""
+  recommendation:  "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher."
+  proofOfConcept: {
+    reproductionSteps: "Precise steps to reproduce go here"
+    environment: "Describe the environment"
+    supportingMaterial: [
+      {
+        content_type: "image/jpeg"
+        encoding: "base64"
+        value: "/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k="
+      }
+    ]
+  }
+  advisories: {
+    title: "GitHub Commit"
+    url: "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+  }
+  advisories: {
+    title: "GitHub Issue"
+    url: "https://github.com/FasterXML/jackson-databind/issues/1931"
+  }
+  created: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  published: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  updated: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  rejected: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  credits: {
+    organizations: {
+      name: "Acme, Inc."
+      url: "https://example.com"
+    }
+    individuals: {
+      name: "Jane Doe"
+      email: "jane.doe@example.com"
+    }
+  }
+  tools: {
+    components: [
+      {
+        type: CLASSIFICATION_APPLICATION,
+        group: "Snyk",
+        name: "Snyk CLI (Linux)",
+        version: "1.729.0",
+        hashes: [
+          {
+            alg: HASH_ALG_SHA_256
+            value: "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+          }
+        ]
+      }
+    ]
+    services: [
+      {
+        provider: {
+          name: "Acme Inc"
+        },
+        name: "Acme BOM Analyzer",
+        endpoints: [
+          "https://example.com/analyze"
+        ]
+      }
+    ]
+  }
+  analysis: {
+    state: IMPACT_ANALYSIS_STATE_NOT_AFFECTED
+    justification: IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_REACHABLE
+    response: VULNERABILITY_RESPONSE_WILL_NOT_FIX
+    response: VULNERABILITY_RESPONSE_UPDATE
+    detail: "An optional explanation of why the application is not affected by the vulnerable component."
+    firstIssued: {
+      seconds: 1641042000
+      nanos: 3
+    }
+    lastUpdated: {
+      seconds: 1643720400
+      nanos: 3
+    }
+  }
+  affects: {
+    ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    versions: {
+      range: "vers:semver/<2.6.7.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.7.0|<2.8.11.1"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.9.0|<2.9.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+  }
+  properties {
+    name: "Foo"
+    value: "Bar"
+  }
+  properties {
+    name: "Foo"
+    value: "You"
+  }
+  properties {
+    name: "Foo"
+    value: "Two"
+  }
+  properties {
+    name: "Bar"
+    value: "Foo"
+  }
+  workaround: "Describe the workarounds here"
+}

--- a/src/test/resources/1.6/valid-vulnerability-tool-1.6.xml
+++ b/src/test/resources/1.6/valid-vulnerability-tool-1.6.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
+    <components>
+        <component type="library" bom-ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4">
+            <group>com.fasterxml.jackson.core</group>
+            <name>jackson-databind</name>
+            <version>2.9.4</version>
+            <purl>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</purl>
+        </component>
+    </components>
+    <vulnerabilities>
+        <vulnerability bom-ref="6eee14da-8f42-4cc4-bb65-203235f02415">
+            <id>SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</id>
+            <source>
+                <name>Snyk</name>
+                <url>https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</url>
+            </source>
+            <references>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+            </references>
+            <ratings>
+                <rating>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&amp;version=3.0</url>
+                    </source>
+                    <score>9.8</score>
+                    <severity>critical</severity>
+                    <method>CVSSv3</method>
+                    <vector>AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</vector>
+                    <justification>An optional reason for rating the vulnerability as it was</justification>
+                </rating>
+            </ratings>
+            <cwes>
+                <cwe>184</cwe>
+                <cwe>502</cwe>
+            </cwes>
+            <description>FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.</description>
+            <detail></detail>
+            <recommendation>Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.</recommendation>
+            <workaround>Describe the workarounds here</workaround>
+            <proofOfConcept>
+                <reproductionSteps>Precise steps to reproduce go here</reproductionSteps>
+                <environment>Describe the environment</environment>
+                <supportingMaterial>
+                    <attachment content-type="image/jpeg" encoding="base64">/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k=</attachment>
+                </supportingMaterial>
+            </proofOfConcept>
+            <advisories>
+                <advisory>
+                    <title>GitHub Commit</title>
+                    <url>https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2</url>
+                </advisory>
+                <advisory>
+                    <title>GitHub Issue</title>
+                    <url>https://github.com/FasterXML/jackson-databind/issues/1931</url>
+                </advisory>
+            </advisories>
+            <created>2021-01-01T00:00:00.000Z</created>
+            <published>2021-01-01T00:00:00.000Z</published>
+            <updated>2021-01-01T00:00:00.000Z</updated>
+            <rejected>2022-01-01T00:00:00.000Z</rejected>
+            <credits>
+                <organizations>
+                    <organization>
+                        <name>Acme, Inc.</name>
+                        <url>https://example.com</url>
+                    </organization>
+                </organizations>
+                <individuals>
+                    <individual>
+                        <name>Jane Doe</name>
+                        <email>jane.doe@example.com</email>
+                    </individual>
+                </individuals>
+            </credits>
+            <tools>
+                <components>
+                    <component type="application">
+                        <group>Snyk</group>
+                        <name>Snyk CLI (Linux)</name>
+                        <version>1.729.0</version>
+                        <hashes>
+                            <hash alg="SHA-256">2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d</hash>
+                        </hashes>
+                    </component>
+                </components>
+                <services>
+                    <service>
+                        <provider>
+                            <name>Acme Inf</name>
+                        </provider>
+                        <name>Acme BOM Analyzer</name>
+                        <endpoints>
+                            <endpoint>https://example.com/analyze</endpoint>
+                        </endpoints>
+                    </service>
+                </services>
+            </tools>
+            <analysis>
+                <state>not_affected</state>
+                <justification>code_not_reachable</justification>
+                <responses>
+                    <response>will_not_fix</response>
+                    <response>update</response>
+                </responses>
+                <detail>An optional explanation of why the application is not affected by the vulnerable component.</detail>
+                <firstIssued>2022-01-01T00:00:00.000Z</firstIssued>
+                <lastUpdated>2022-02-01T00:00:00.000Z</lastUpdated>
+            </analysis>
+            <affects>
+                <target>
+                    <ref>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</ref>
+                    <versions>
+                        <version>
+                            <range>vers:semver/&lt;2.6.7.5</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.7.0|&lt;2.8.11.1</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.9.0|&lt;2.9.5</range>
+                            <status>affected</status>
+                        </version>
+                    </versions>
+                </target>
+            </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
+        </vulnerability>
+    </vulnerabilities>
+</bom>

--- a/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.json
+++ b/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.json
@@ -1,0 +1,155 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+      "type": "library",
+      "group": "com.fasterxml.jackson.core",
+      "name": "jackson-databind",
+      "version": "2.9.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "6eee14da-8f42-4cc4-bb65-203235f02415",
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111",
+      "source": {
+        "name": "Snyk",
+        "url": "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+      },
+      "references": [
+        {
+          "id": "CVE-2018-7489",
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+          }
+        }
+      ],
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+          },
+          "score": 9.8,
+          "severity": "critical",
+          "method": "CVSSv3",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "justification": "An optional reason for rating the vulnerability as it was"
+        }
+      ],
+      "cwes": [
+        184,
+        502
+      ],
+      "description": "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.",
+      "detail": "",
+      "recommendation": "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.",
+      "workaround": "Describe the workarounds here",
+      "proofOfConcept": {
+        "reproductionSteps": "Precise steps to reproduce go here",
+        "environment": "Describe the environment",
+        "supportingMaterial": [
+          {
+            "contentType": "image/jpeg",
+            "encoding": "base64",
+            "content": "/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k="
+          }
+        ]
+      },
+      "advisories": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/1931"
+        }
+      ],
+      "created": "2021-01-01T00:00:00.000Z",
+      "published": "2021-01-01T00:00:00.000Z",
+      "updated": "2021-01-01T00:00:00.000Z",
+      "rejected": "2022-01-01T00:00:00.000Z",
+      "credits": {
+        "organizations": [
+          {
+            "name": "Acme, Inc.",
+            "url": [
+              "https://example.com"
+            ]
+          }
+        ],
+        "individuals": [
+          {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com"
+          }
+        ]
+      },
+      "tools": [
+        {
+          "vendor": "Snyk",
+          "name": "Snyk CLI (Linux)",
+          "version": "1.729.0",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": ["will_not_fix", "update"],
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component.",
+        "firstIssued": "2022-01-01T00:00:00.000Z",
+        "lastUpdated": "2022-02-01T00:00:00.000Z"
+      },
+      "affects": [
+        {
+          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4",
+          "versions": [
+            {
+              "range": "vers:semver/<2.6.7.5",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.7.0|<2.8.11.1",
+              "status": "affected"
+            },
+            {
+              "range": "vers:semver/2.9.0|<2.9.5",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "Foo",
+          "value": "Bar"
+        },
+        {
+          "name": "Foo",
+          "value": "You"
+        },
+        {
+          "name": "Foo",
+          "value": "Two"
+        },
+        {
+          "name": "Bar",
+          "value": "Foo"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.textproto
+++ b/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.textproto
@@ -1,0 +1,146 @@
+# proto-file: schema/bom-1.6.proto
+# proto-message: Bom
+
+spec_version: "1.6"
+version: 1
+serial_number: "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+components {
+  type: CLASSIFICATION_LIBRARY
+  bom_ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+  group: "com.fasterxml.jackson.core"
+  name: "jackson-databind"
+  version: "2.9.4"
+  purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+}
+vulnerabilities {
+  bom_ref: "6eee14da-8f42-4cc4-bb65-203235f02415"
+  id: "SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  source: {
+    name: "Snyk"
+    url: "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111"
+  }
+  references: {
+    id: "CVE-2018-7489"
+    source: {
+      name: "NVD",
+      url: "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
+    }
+  }
+  ratings: {
+    source: {
+      name: "NVD"
+      url: "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
+    }
+    score: 9.8
+    severity: SEVERITY_CRITICAL
+    method: SCORE_METHOD_CVSSV3
+    vector: "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    justification: "An optional reason for rating the vulnerability as it was"
+  }
+  cwes: 184
+  cwes: 502
+  description: "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath."
+  detail: ""
+  recommendation:  "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher."
+  proofOfConcept: {
+    reproductionSteps: "Precise steps to reproduce go here"
+    environment: "Describe the environment"
+    supportingMaterial: [
+      {
+        content_type: "image/jpeg"
+        encoding: "base64"
+        value: "/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k="
+      }
+    ]
+  }
+  advisories: {
+    title: "GitHub Commit"
+    url: "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
+  }
+  advisories: {
+    title: "GitHub Issue"
+    url: "https://github.com/FasterXML/jackson-databind/issues/1931"
+  }
+  created: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  published: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  updated: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  rejected: {
+    seconds: 3173618478
+    nanos: 3
+  }
+  credits: {
+    organizations: {
+      name: "Acme, Inc."
+      url: "https://example.com"
+    }
+    individuals: {
+      name: "Jane Doe"
+      email: "jane.doe@example.com"
+    }
+  }
+  tools: {
+    vendor: "Snyk"
+    name: "Snyk CLI (Linux)"
+    version: "1.729.0"
+    hashes: {
+      alg: HASH_ALG_SHA_256
+      value: "2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d"
+    }
+  }
+  analysis: {
+    state: IMPACT_ANALYSIS_STATE_NOT_AFFECTED
+    justification: IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_REACHABLE
+    response: VULNERABILITY_RESPONSE_WILL_NOT_FIX
+    response: VULNERABILITY_RESPONSE_UPDATE
+    detail: "An optional explanation of why the application is not affected by the vulnerable component."
+    firstIssued: {
+      seconds: 1641042000
+      nanos: 3
+    }
+    lastUpdated: {
+      seconds: 1643720400
+      nanos: 3
+    }
+  }
+  affects: {
+    ref: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4"
+    versions: {
+      range: "vers:semver/<2.6.7.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.7.0|<2.8.11.1"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+    versions: {
+      range: "vers:semver/2.9.0|<2.9.5"
+      status: VULNERABILITY_AFFECTED_STATUS_AFFECTED
+    }
+  }
+  properties {
+    name: "Foo"
+    value: "Bar"
+  }
+  properties {
+    name: "Foo"
+    value: "You"
+  }
+  properties {
+    name: "Foo"
+    value: "Two"
+  }
+  properties {
+    name: "Bar"
+    value: "Foo"
+  }
+  workaround: "Describe the workarounds here"
+}

--- a/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.xml
+++ b/src/test/resources/1.6/valid-vulnerability-tool-deprecated-1.6.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
+    <components>
+        <component type="library" bom-ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4">
+            <group>com.fasterxml.jackson.core</group>
+            <name>jackson-databind</name>
+            <version>2.9.4</version>
+            <purl>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</purl>
+        </component>
+    </components>
+    <vulnerabilities>
+        <vulnerability bom-ref="6eee14da-8f42-4cc4-bb65-203235f02415">
+            <id>SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</id>
+            <source>
+                <name>Snyk</name>
+                <url>https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111</url>
+            </source>
+            <references>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+                <reference>
+                    <id>CVE-2018-7489</id>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln/detail/CVE-2019-9997</url>
+                    </source>
+                </reference>
+            </references>
+            <ratings>
+                <rating>
+                    <source>
+                        <name>NVD</name>
+                        <url>https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&amp;version=3.0</url>
+                    </source>
+                    <score>9.8</score>
+                    <severity>critical</severity>
+                    <method>CVSSv3</method>
+                    <vector>AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</vector>
+                    <justification>An optional reason for rating the vulnerability as it was</justification>
+                </rating>
+            </ratings>
+            <cwes>
+                <cwe>184</cwe>
+                <cwe>502</cwe>
+            </cwes>
+            <description>FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.</description>
+            <detail></detail>
+            <recommendation>Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.</recommendation>
+            <workaround>Describe the workarounds here</workaround>
+            <proofOfConcept>
+                <reproductionSteps>Precise steps to reproduce go here</reproductionSteps>
+                <environment>Describe the environment</environment>
+                <supportingMaterial>
+                    <attachment content-type="image/jpeg" encoding="base64">/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAABQKADAAQAAAABAAABQAAAAAD/wAARCAFAAUADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9sAQwACAgICAgIDAgIDBQMDAwUGBQUFBQYIBgYGBgYICggICAgICAoKCgoKCgoKDAwMDAwMDg4ODg4PDw8PDw8PDw8P/9sAQwECAgIEBAQHBAQHEAsJCxAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ/90ABAAU/9oADAMBAAIRAxEAPwD9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9D9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9H9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9L9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9P9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9T9xKKKKACiiigAooooAKKKKACiiigAooooAKKzdY1jSfD2lXWua7eRafp9jG0s9xO4SONF6szHgCvyK+P/APwUJ1zV7i68MfAxTpmnKTG2sTJ/pU3Ym3jbIiU9mYFz1AWmkB+qvjL4ieA/h5Z/bvHPiCy0OEjK/a51jZv91CdzfgDXy3r/APwUA/Zw0WVobPUr/WWXvZ2T7D9GmMQNfitofhT4ofGXX5ptHsdR8V6rK2Zrht85BPeSaQ7V/wCBMK+nvDv7Afxk1WJZtcvtL0PdzskmeeQfUQqVz/wI185nXF+VZc+XG4mMH2b1+5Xf4HTRwlWprCLZ9xW//BSD4DSy7JtO12Bf77WsBH5LOT+leweEP2yv2cfGc0drZeL4tNuJOBHqUclmST23yKI//H6/Om4/4J2eOli3Wvi/TJJP7rwzoPzAb+VeL+NP2NPjx4Ohku00aPXrWPJL6ZKJ2x/1yYLIfwU15WX+JeQYqfs6OMhfzfL/AOlJGk8trxV3Bn9Ctpd2t/bR3thPHc28w3JLEweNwe6spII+lWK/me+G3xr+LfwN1hj4P1e50zyXxcadcBmtnI6rLbScA+4CsOxr9mP2bv2x/Bfxz8rwzrUaeHfGIX/jzd8wXeBy1q7ck9zG3zDtuGTX2+6ujiPsmiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1f3EooooAKKKKACiiigAooooAKKKKACop54LWCS6upFhhhVnkdyFVEUZZmJ4AAGSalr88P8AgoV8aJ/BXgCz+F+hXBi1PxeGa7ZDho9OiOGX285/k91DChAfDv7Xn7Uuo/GzxHN4V8LXL2/gbSZSIUUlft8qHH2mUd1z/qlPAHzH5jx1P7NH7HM/j21tfHvxQWWy8Py4ktbBSY571ezu3WOE9sfMw5GBgnhP2PfgTB8WfGsviHxJb+b4Z8NsjzIw+W6uTzFAfVRjc49MD+Kv2w/dxR/wxxxr7Kqqo/IAD8q/nbxl8VauAm8pyyVqlvfkt432S/vNat9Fa2r0+hyjK1Ne1qbdEZWgeHtB8K6VDofhrT4NL0+3GI4LeMRoPfA6n1J5Pc1sV8+X/wC1V+z9pustoV14ytTOjbGeNJZIFYcYMyIU/EEj3r3iw1Cw1Wyg1LS7mO8tLpBJFNC4eORG5DKy5BB9q/lbM8px1C1XG0px59U5Jrm+bWp9NTqwlpBrTsW6KKK8k1PD/jD+z78OvjRp8ieI7IWurBcQanbKFuoz23HpInqr59sHmvxc+K/wl8c/AbxlHpWtFo3VvP0/UbYsiTqjZWSJxyrqcblzuU+2Cf6E68r+Mnwn0H4yeBb3wfraqkrAyWVzjL2t0o+SRT1x2cd1JHpX7D4ZeKuJyevHDYqTlhno09eTzj6dY7P1PJzLLI1k5RVpfmef/sZftQn41aA/gvxnMo8Z6JEGaQ4X+0LZcL54H/PRTgSgeoYdSB9yV/MPoWs+M/gP8U4dTgU2XiDwnfFZIySFYxNtkjb1jkXI91Oa/pQ8E+LtI8feENG8a6C++w1u1iuovVRIuSp91OVPuDX9ywqRnFTg7p6pnxTTTszqKKKKoQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//W/cSiiigAooooAKKKKACiiigD8fP2q/21fiZo/wAStW+Hnwsvl0LTvD0xtZ7pYkkuLm4T/WYaQMERW+UBRk4yTg4r5Z/4bJ/aZ/6Hu6/79W//AMbr6u/a+/Yz8cX3jLWfi18L7U63Zau5u77Tov8Aj7gnI/ePEn/LVHI3bV+YEkYIr8z9Ovrnw9qhe4soppYGKS295CHGQeVZGAKkfgRTe2iNKUYuSU3Zd9z6C/4bJ/aZ/wCh7uv+/Vv/APG68Z8e/EXxr8T9dHiXx7qsusaksKQCaUKCIoySqgIFAAJJ6d6+gPBPiT4Q+KvLs9Q0Gx0rUWwPLliTy3P+xIQB+BwfrWR8efDHh3Q9E0u40bTYLGWS5ZGaGMIWXYTg468ivIp5x+/VCdNxbPv8TwBbLp5lh8VCpCO9r33StqtHrsz9EP2G9X8J33wOt9M8PKY7/TbqZdUV8bmuZTvWTjqjR7QvptI7VN+3B4o1vw18C7iHRZHg/tm+gsbmRCQRburu65HQOUCn1BI714P/AME5Wbb48TJ2/wDEvOO2f33NfoJ8QvAXh74m+D9R8E+KImksNRQAlDiSN1O5JEJzhkYAj8jwTX8Y8WTw+VcaTr105041Izd9X7yUn62b0XkkcOFUquDSjo7W/Q/m/wCnAr9XP+CePifWr/wx4q8KXkjy6bpM9tPa7iSImuQ/mIvoCUDY9cnvXll//wAE8PiAmsmDTPFGmS6UW4nmWZJwnvEqspbHo+K/Qz4KfBrw58EfBq+FdBka7mmk8+8u5AFe4nIA3YGdqqBhVycDuSSa/UfF/wASMlx2SywmEqqpUm4tWT92zTbd0rO11bfXseblOXVoVueaskev0UUV/JR9SFFFFAH5F/8ABQLwFDovj7RvH1lGEj8R2zQ3GBgG5tMAMfdo2X/vmvrj/gnD43l174Qat4NupN8vhfUT5QJ5FveL5qj6CQSfnXHf8FBNPiuPg/o+oMP3llrEQU9wssMqsPxwPyrzP/gmNqEqeNvHWlZ/dTabazkf7UU5Qfo5r+9vBfNJ4rh2h7R3cLw+Sen3JpfI+Hziko4iVuup+xNFFFfqR5YUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1/3EooooAKKKKACiiigAooooAK+cPjd+yz8KfjnBJda9Y/2Zr+3Eeq2QVLgHt5o+7Mvs/Powr6Pr57/aW+PFp+z78PB4s+wjU9SvrhbOxtmYpG8zKzlpGHIRFUk45JwBjOQ0B+MHxz/ZJ+KvwOabVL+1GueGkPy6rZKWjRScD7RHy0J+uVz0Y18+XvibXdS0i30LULt7mztH8yFZDuKHG3AY84x26V6f8Wf2iPi18abpm8ba3I1gG3R6fbfuLKP0xEp+Yj+85Y+9eJU3BOza2NqWIqQUowk0no7dV2fc/Tr/AIJy/wDM+f8AcP8A/a1fp1X5mf8ABOa2mFt47vCP3RewjB/2gJmI/Kv0zr+CPGlp8S4q39z/ANIifZ5P/u8fn+YUUUV+WHphRRRQAUUUUAfAv/BQrWIbX4X+H9DLfvtQ1YSgf7FvC+4/m61xv/BMXSJX8SePNf2nyobOztM9t0sryY/KOvDP26PiNB4x+LMfhXTpRJZeEYDbMQcqbuUh5/8AvnCofdTX6Ff8E+/AE3hD4EJ4hvY/LuvF15JfjIwfs0YEMH4EKzD2av798H8nnguH8PCorSneb/7ed1/5LY+Fzasp15NdND7looor9LPNCiiigAooooAKK5rxf4x8MeAfD134r8Y6lFpWlWK7pZ5jhRngKAMlmY8KqgknoK+KW/4KOfAVdW+wCy1prPdt+2C1j8vH97yzL5mP+A59qLAffdFcp4K8ceE/iL4ctfFngrU4tV0q7zsmiJ4ZfvIynDK691YAiuroAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAK8J/aH+Bej/ALQHw/bwdqN42m3dtOt3Y3arv8mdVK/MmRuRlYqwBB7jkV7tRQB+MDf8EzPiiCQvi/RiOx2XIz+Gyuf8V/8ABOn4seGfC+q+IrbXNN1ibTLd7hbK1Sfz5xHyyx7lA3bckDuRgcmv2/r5b/ay+P8AqX7Pnw+ste0Cwiv9Y1i8Fnai43GCLCNI8jhSC2AMBQRknk4FVcD8Xv2cvjbefA/x/HrMwebQ9RAttTt16tDnIkUf89IjyPUZXvX7xaLrWk+I9JtNe0K7jvtOv41mgniO5JEbkEH+Y6g8Hmv5yPG3iqXxv4p1HxZc6faaZcapIZpobFGit/Nb77IjM23efmIBxknAFe2fAH9prxh8Drv+z1U6x4ZuH3z6fI+0ox6yW7nOxz3GNrdxnkfhni54UvOF9fwFlXirNbKaW2vSS6N6NaPZHt5Vmnsv3c/h/I/d6iuY8F+LtG8e+FNL8ZeH3Z9P1eBZ4t42uA3BVhzhlIIPuK6ev4tr0J0pypVFaUW00+jW6PsIyTV0FFFRT3EFpBJdXUqQwxKWeSRgqKo6lmOAAPU1mlfRDJa+bP2lvj5pnwS8GyCzlSXxTqqNHp1v1KE8G4kHZI+2fvNgDvjzP40/tt+A/A9vcaN8Onj8U69gqJUJ+wQN6tIMeaR/dTg92FflvHH8S/j78RViQT+IvE+uSYHoAP8Ax2KKMfRVFfv3hj4NYnG1oY3NabhRWqi9JT+W6j3vutFvdeFmWbxgnCk7v8ja+Cnws8Q/Hv4qWPhOB5Jft0xutTuzljFbBt08zMf4jnC56uwr+k3SdK07QdKstD0iEW1jp8MdvBEvRIolCoo+gFfP/wCzL+zpo37P/go6bEVv/EWqBJNUvlXh3UfLDFnkRR5OP7xyx64H0kUcdVI/Cv7J0WiPkBtFGCKKACilCk9Bmql/e2WlWz3uq3EVlbxjc8k7rEij1LMQAKALVVb6+stMs59R1K4jtLS2QySzTOI440XkszNgAD1NfGHxa/bw+C/w7jmsPDFyfGespkCKwbFqrf8ATS6IK4/65hz9K/Jf40/tMfFb473f2fxPf/ZdI35h0qy3R2qnPy7lyWlf3cn2A6U0gPbP25P2idC+MfijS/C3gPUHvPDPh5ZGeUApDdXrnBkTPLIiDarEDqxHBzXgi/AbxF/wol/jxJewx6cLsW62jKwmeMy+T5ob7uN/AHoCc9q92+Af7FninxzNbeJvidHLoHh7IkW1YbL27XqBtPMKHuzfMR0HevsD9suw0rw1+zLd6Bo1tHZWMFzp1tbwRDakcaSghVH0WvxziLxToLNcJlOWTUpyqRU2rNKLdnFPu+62t329jD5ZL2U6tRWSTsfPH/BNjxlrNl8TNe8BrKX0nVdOe9aIn5UuLV0VZFHqyOVPrgegr9oa/D3/AIJvW5l+OuqTgcQaHck/8CmhFfuFX7HI8cKKKKQBRRRQAUUUUAFFFFAH/9H9xKKKKACiiigAooooAKKKKACiiigAr83P+CmUBf4WeEbgDiLW2B/4FbSf4V+kdfBX/BRjS2vfgBb36jJ07WrOQ+yyJLGf1YU0B+ef7JXwK8DfHG58UWPjGW8hfSYrWS3a0lWMjzWdW3BkcH7ox0r6suv+Cd/w5kmV7PxTq0MWRuRkgcle4DbVwfcg14p/wTw1IQfEbxRpRODeaUkoHqYJ1H8pK/XCv5D8WeOs6yzPq1DCYmUYWi0tGtYq9k0+tz6zK8FRqUFKcbvU5zwh4U0bwN4Y0zwh4eiMOm6TAsEKsdzbV7se7Mckn1NdHRRX871q06k5VKjvJu7b3be7PfSSVkFfOX7VXgLxn8R/g5qPhvwKTJqHnwTvbBwhuoYiS8QJIGScMATglcelfRtFd2TZrUwOLpYykk5QkpK+qunfUitSU4uD6n88t78BPjZp2ftfgXWEx/ds5H/9ABrmZvAvxE0d/Mn8PatYuv8AEbS4jI/HYDX9IOSOhpwkkHRiPxr+gaP0ksYv4mEi/STX5pngvh6HSbP5u49e+I+lf6rUtZstvpPcxY/UVpQ/GD4s2J2weNdahI7DULgf+z1/RbIkcv8ArkWT/eAP86oy6RpE4xPYW8g/2oUb+Yr06f0lV9vA/dU/+0M3w72n+H/BP59ov2g/jlBxF8Q9dUf9hKf/AOLqz/w0d8eiMf8ACxddx/2EJv8A4qv3tk8HeEJuZtB09/8AetIT/Nag/wCEE8DZz/wjemZ/68oP/iK6l9JSh1wT/wDA1/8AIk/6uv8An/A/Am6+PHxpvVK3fj/XJQeobUrj/wCLrnmHxF8eTrC/9r+I5nPyq32i8JPsDur+iS38L+F7QhrXRrGEjulrEv8AJa11MFmm1NsK+igKPyFc1f6Sd1ajgdfOf6KBcOHO8/w/4J+Kvw1/Yk+MHjZ4rrxHAnhHTGwS9781yV/2LdTuz/vlK/ST4SfsufCn4RGLUNNsTq+tx4P9o34WSVW9Ykxsi/4CN3+0a96l1KMcRLuPqeBVq2nFxHvxgg4Ir8s4w8T89zSDjWn7Ok/sw0Xzd+Z+jdvI9fD5NTormtd92WCSTk18M/8ABQDUha/BjTdPzhr/AFiAY9RFFK5/XFfc1fmL/wAFF9eGPBPhZG5/0y+df++IkP8A6HXF4RYJ1+I8JFdG5f8AgMW/0JzWfLh5srf8EytMM3xC8aaxji10qCDPvPOG/wDaVfsnX5h/8EyfD7W/g3xt4odcfbb+2tEb1FtEXb9ZRX6eV/oDI+DCiiikAUUUUAFFFFABRRRQB//S/cSiiigAooooAKKKKACiiigAooooAK+aP2w/DreJv2bfG9nGm+SztUvkHvZypMT+Cqa+l6yte0a08R6FqXh6/GbbVLaa1kB/uToUP6GgD+fv9i3xEugftBaHFK22PWIbmwPpuljLp+boB+NfuTX841jNq3wn+JcMsylNQ8I6qN69DvspsMPx2kfQ1/RZpuo2esadaavp7iS1voY54mHIaOVQ6n8jX8ifSNylwx+HxqWk4uPzi7/lJfcfWcP1b05Q7P8AMu0UUV/OR9AFFFFAGHNfXAlYKdoBxjFMGoXI/iB/Ctp4IZDudASe9Rmztj/yzH617EMbh7JOH5HUqsLaozBqVx/sn8KX+05v7q/rV/7Ban+D9TSf2fa/3T+dV9awv8g/aU+xS/tOb+4v60h1Oc9FUfnV3+z7b0P50o0+1H8JP40fWMJ/KHPS7GU95cvwXwPbiokimmPyqW966BLW3j+6gz781PQ80hFWpQB4hL4UczNA8BAkxkjPFa2mjEBPq1Z19J5lw2Oi8flWxaJ5dug7kZP41rj6reHjzbsqtJ8iuWa/ED9tjxcvij486pZQvvt/D0EGnLg8B0HmS/8Aj7kH6V+zni/xRp/grwrq/i/VWC2mj2st1JnuI1JCj3Y4A9zX88+l2GvfFv4kW2nrmbV/F2phSev728lyx+i7ifoK/cfo55E6mNr5jJaQjyr1lq/uS/8AJj5HiCvaEaffU/df9iDwi3hL9m/w0Zo/LuNba41OTPXFxIRH/wCQ1SvrSsvRNGsfDui6f4f0xAlnplvFawqO0cKBF/QVqV/XDPlAooooAKKKKACiiigAooooA//T/cSiiigAooooAKKKKACiiigAooooAKKKKAPwj/4KAfDGTwT8bH8XWkOzTPGcIu1YD5RdxAR3C/U/K/8AwKvrz9h/4oR+NfhSvg++m3ar4RYWxUn5ms3y0D/ReY/+Aj1r6M/at+Cg+OHwkv8AQtPjDa9pRN/pbdzcRqd0OfSZMp/vbT2r8Mvgn8U9Y+CPxJs/FMcUhhiZrXUbQ/K0luxxKhB6OhG5c9GUe9fn3ifwe86ymeHpr95H3oeq6fNXXrZ9D0Mtxfsaqk9noz+hGisfw94g0fxXodj4k8PXS3um6lEs0EyHhkYcfQjoR1ByDWxX+fdSnKEnCas1o0+jPu076oKKKKgYUUUUAFFFFABRRR70AFVrq4FvGT/Efuio576KLIT529un51jM0tzLk/MzdK9TB5e5PmqaI6aVBvV7C28RnmC9up+ldLVW1thbpg8s3U15p8ZPi14f+DPgi78X64wkmAMdla5w91ckfJGvsOrn+Fcn0rZ0quOxMMNho80m7RS6tmWKxEVeTeiPjP8Ab6+LkdlpFh8HtHn/ANJvyl7qe0/cgQ5gib/fYbyPRV9a4r/gnP8ACZ/EXxA1H4ranDnT/C8Zt7RmHD31yuCR/wBcoiSfQutfEUj+NvjZ8Scqrap4l8VXoCqvQySnAA/uxov4Ki+1f0Y/Bf4WaR8Gfhto3w/0giT7BHuuZwMG4upPmmlP+83T0UAdq/0A4E4UhkuWU8DHWW8n3k936dF5JH51jsU61Rz+49Sooor645AooooAKKKKACiiigAooooA/9T9xKKKKACiiigAooooAKKKKACiiigAooooAK/Ij9u79ly4sr28+Ofw/szJZ3B8zXLSJeYpO94ij+Bv+WuOjfP0Jx+u9MkjjmjeGZBJHICrKwBVlIwQQeCCOoppgfz5/syftO6n8FdQ/wCEe8QCTUPB99JulhX5pLSRus0APUH+NP4uo+br+0fhvxN4f8Y6Ja+I/C9/Fqem3i7op4W3KfUHuGHQqcEHgivz4/ah/YPvLa4vPH/wLtPtFtIWlutDT/WRE8s1n/eX/pl1H8GR8o+Bvhr8XviT8FNcluPCd9JYsJNt3YXCkwSsvBWaFsYYdMjDD1r8Q8SvBujm8pY3AtQr9b/DP17Pz69V1Pay7N3S9yesfyP6HKQ5wcda+Ffhl+3j8N/E8cVh8QraTwrqJwGmAa4smb1DqN6fRlIH96vs/wAP+J/DfiyzXUPC+q2ur2zDIktZkmX8dhOPxr+SM+4RzLK58mOoSh5291+klo/kz6qhiqdRXg7ldp7lJCWdlbvzUq6hcr1Ib6it1kR+HUH6ioGs7Zv+WYH0rlWYUZL34Hp+3g90Zo1Kfuqn86Dqc3ZV/Wrx0+29D+dH9n23ofzp/WMJ/KPnpdjObULk9CB9BVZ5ZpjhmLe1bq2Vsv8ABn6mrCRonEagfQUf2hRh8EA9vBfCjCisZ5OWGwep/wAK2ILaO3GEGSepPWuS8Y/EbwH8PrVrzxrr1npCAZCzygSt/uxjLsfopr4H+LH7f9jDHNpPwe0xriY5X+0tQTbGv+1Fb5y3sZCB/smvoci4SznO5KODovk/m2ivWT0forvyPOxmaQgvfl8j7X+LXxk8D/Bnw82ueL7sCaQH7LZREG5unH8Ma9hnq5+Ve57V+Hnxf+L/AIx+OHjD+3/EBIUHybCxhy0dvGx+WONerOxxubGWP4AYLv8AEb40eNVU/bfFXiXVX2qoBllb2AHCIv4Ko9BX7Dfsr/sVaX8J5Lbx98SRDqvi9QHt7dcSW2nE91PSSYf3/ur/AA5PzV/XPhz4VYXIY+3qP2ldrWXReUf1e78lofGZhmkq/urSJJ+xT+yzJ8JdI/4WP48tgvi/V4dsEDjJ061cZKn0mk/j/uj5eu6vvyiiv1Q8sKKKKACiiigAooooAKKKKACiiigD/9X9xKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvnL40fssfCP44LJe+I9OOna4y4XVLHEVzkdPM4KSgf7YJ9CK+jaKAPwv+Jv8AwT3+Mvg55rzwS8HjLTkyVFuRBehf9qCQ4Y/7jtn0r45v9L8e/DXVtmo2upeFtSjPV1ms5c+x+Un8DX9S1UdT0vS9atWsdasoNQtm4MVxEsyEf7rgiiSUk4yV0xp2P5zPD/7Vf7QHhxUSz8ZXV1EvRLxY7sfnKrN+terad+3x8crQBb2HSb8Du9q0bH8Y5FH6V+sniP8AZO/Z08UO8upeBNPhlfkvaB7Rs+v7hkH6V5Fqf/BPP9nS+YtZwarp2f8AnjfFgPoJVevlMbwHkmId62Dpt9+VJ/ekmdUMdWjtN/efEEP/AAUP+JiDE3hfR5D6g3C/+1KfL/wUQ+JLLiLwto6H1LXDf+1BX1fP/wAE1vgw7E2/iDXYh6NLbP8A+0RUcP8AwTU+DitmfxFrkg9A9uv6+Sa8n/iFHDl7/U4/fL/M1/tXEfznxVqf7fPxwvAVsINJ04Hulq0jD8ZJGH6V474m/ae+PPipHi1TxleQQv1jtClomD2/cqhx+NfrLpf/AATw/Z2sGDXseraljtPfbAfqIUjr2Xwz+yp+zx4SdJtJ8CadJMnIku0a8fPrm4aQfpXr4DgTJMM+ahg6afflTf3u7MZ46tL4pv7z+fPw34J+IfxN1Qx+F9G1HxJfTH5nhikuDk93lOQPqzV93fCr/gnH49154dS+K+qReGrE4ZrO1K3N6w9Cw/dR/XLn2r9l7Ozs9OtlstOt47S3ThYoUWNAPZVAA/KrNfVrRWRynlXwr+Cnw1+DGknSvh/o0di0gAnun/eXdxjvLM3zH/dGFHYCvVaKKQBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/1/3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0P3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0f3EooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAP/0v3Eoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQBRoq9/Z15/zz/UUf2def8APP8AUUAUaKvf2def88/1FH9nXn/PP9RQBRoq9/Z15/zz/UUf2def88/1FAFGir39nXn/ADz/AFFH9nXn/PP9RQB//9k=</attachment>
+                </supportingMaterial>
+            </proofOfConcept>
+            <advisories>
+                <advisory>
+                    <title>GitHub Commit</title>
+                    <url>https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2</url>
+                </advisory>
+                <advisory>
+                    <title>GitHub Issue</title>
+                    <url>https://github.com/FasterXML/jackson-databind/issues/1931</url>
+                </advisory>
+            </advisories>
+            <created>2021-01-01T00:00:00.000Z</created>
+            <published>2021-01-01T00:00:00.000Z</published>
+            <updated>2021-01-01T00:00:00.000Z</updated>
+            <rejected>2022-01-01T00:00:00.000Z</rejected>
+            <credits>
+                <organizations>
+                    <organization>
+                        <name>Acme, Inc.</name>
+                        <url>https://example.com</url>
+                    </organization>
+                </organizations>
+                <individuals>
+                    <individual>
+                        <name>Jane Doe</name>
+                        <email>jane.doe@example.com</email>
+                    </individual>
+                </individuals>
+            </credits>
+            <tools>
+                <tool>
+                    <vendor>Snyk</vendor>
+                    <name>Snyk CLI (Linux)</name>
+                    <version>1.729.0</version>
+                    <hashes>
+                        <hash alg="SHA-256">2eaf8c62831a1658c95d41fdc683cd177c147733c64a93e59cb2362829e45b7d</hash>
+                    </hashes>
+                </tool>
+            </tools>
+            <analysis>
+                <state>not_affected</state>
+                <justification>code_not_reachable</justification>
+                <responses>
+                    <response>will_not_fix</response>
+                    <response>update</response>
+                </responses>
+                <detail>An optional explanation of why the application is not affected by the vulnerable component.</detail>
+                <firstIssued>2022-01-01T00:00:00.000Z</firstIssued>
+                <lastUpdated>2022-02-01T00:00:00.000Z</lastUpdated>
+            </analysis>
+            <affects>
+                <target>
+                    <ref>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.4</ref>
+                    <versions>
+                        <version>
+                            <range>vers:semver/&lt;2.6.7.5</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.7.0|&lt;2.8.11.1</range>
+                            <status>affected</status>
+                        </version>
+                        <version>
+                            <range>vers:semver/2.9.0|&lt;2.9.5</range>
+                            <status>affected</status>
+                        </version>
+                    </versions>
+                </target>
+            </affects>
+            <properties>
+                <property name="Foo">Bar</property>
+                <property name="Foo">You</property>
+                <property name="Foo">Two</property>
+                <property name="Bar">Foo</property>
+            </properties>
+        </vulnerability>
+    </vulnerabilities>
+</bom>


### PR DESCRIPTION
According to the [docs](https://cyclonedx.org/docs/1.5/json), since v1.5 the `Tools` format has been deprecated and a new format recommended. While the entity `Metada` has been updated to use the new format (new method `setToolChoice`), `Vulnerability` has not. This PR adds a similar method to `Vulnerability`.  