### PR TITLE
Teach versions / generators about their supported file formats

### DIFF
--- a/src/main/java/org/cyclonedx/CycloneDxMediaType.java
+++ b/src/main/java/org/cyclonedx/CycloneDxMediaType.java
@@ -18,6 +18,7 @@
  */
 package org.cyclonedx;
 
+@Deprecated
 public class CycloneDxMediaType {
 
     private CycloneDxMediaType() { }

--- a/src/main/java/org/cyclonedx/Format.java
+++ b/src/main/java/org/cyclonedx/Format.java
@@ -1,13 +1,15 @@
 package org.cyclonedx;
 
 public enum Format {
-    XML("xml"),
-    JSON("json");
+    XML("xml", "application/vnd.cyclonedx+xml"),
+    JSON("json", "application/vnd.cyclonedx+json");
 
     private final String extension;
+    private final String mediaType;
 
-    Format(String extension) {
+    Format(String extension, String mediaType) {
         this.extension = extension;
+        this.mediaType = mediaType;
     }
 
     /**
@@ -17,5 +19,15 @@ public enum Format {
      */
     public String getExtension() {
         return extension;
+    }
+
+    /**
+     * The official CycloneDX media type assigned by IANA for this format, see
+     * https://cyclonedx.org/specification/overview/#registered-media-types.
+     *
+     * @return The identifier for the media type.
+     */
+    public String getMediaType() {
+        return mediaType;
     }
 }

--- a/src/main/java/org/cyclonedx/Format.java
+++ b/src/main/java/org/cyclonedx/Format.java
@@ -1,0 +1,21 @@
+package org.cyclonedx;
+
+public enum Format {
+    XML("xml"),
+    JSON("json");
+
+    private final String extension;
+
+    Format(String extension) {
+        this.extension = extension;
+    }
+
+    /**
+     * The file extension associated to this format.
+     *
+     * @return The file extension, excluding the dot.
+     */
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/src/main/java/org/cyclonedx/Version.java
+++ b/src/main/java/org/cyclonedx/Version.java
@@ -1,20 +1,26 @@
 package org.cyclonedx;
 
+import java.util.EnumSet;
+
+import static org.cyclonedx.Format.*;
+
 public enum Version
 {
-  VERSION_10(CycloneDxSchema.NS_BOM_10, "1.0", 1.0),
-  VERSION_11(CycloneDxSchema.NS_BOM_11, "1.1", 1.1),
-  VERSION_12(CycloneDxSchema.NS_BOM_12, "1.2", 1.2),
-  VERSION_13(CycloneDxSchema.NS_BOM_13, "1.3", 1.3),
-  VERSION_14(CycloneDxSchema.NS_BOM_14, "1.4", 1.4),
-  VERSION_15(CycloneDxSchema.NS_BOM_15, "1.5", 1.5),
-  VERSION_16(CycloneDxSchema.NS_BOM_16, "1.6", 1.6);
+  VERSION_10(CycloneDxSchema.NS_BOM_10, "1.0", 1.0, EnumSet.of(XML)),
+  VERSION_11(CycloneDxSchema.NS_BOM_11, "1.1", 1.1, EnumSet.of(XML)),
+  VERSION_12(CycloneDxSchema.NS_BOM_12, "1.2", 1.2, EnumSet.of(XML, JSON)),
+  VERSION_13(CycloneDxSchema.NS_BOM_13, "1.3", 1.3, EnumSet.of(XML, JSON)),
+  VERSION_14(CycloneDxSchema.NS_BOM_14, "1.4", 1.4, EnumSet.of(XML, JSON)),
+  VERSION_15(CycloneDxSchema.NS_BOM_15, "1.5", 1.5, EnumSet.of(XML, JSON)),
+  VERSION_16(CycloneDxSchema.NS_BOM_16, "1.6", 1.6, EnumSet.of(XML, JSON));
 
   private final String namespace;
 
   private final String versionString;
 
   private final double version;
+
+  private final EnumSet<Format> formats;
 
   public String getNamespace() {
     return this.namespace;
@@ -28,9 +34,14 @@ public enum Version
     return version;
   }
 
-  Version(String namespace, String versionString, double version) {
+  public EnumSet<Format> getFormats() {
+    return formats;
+  }
+
+  Version(String namespace, String versionString, double version, EnumSet<Format> formats) {
     this.namespace = namespace;
     this.versionString = versionString;
     this.version = version;
+    this.formats = formats;
   }
 }

--- a/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
@@ -3,6 +3,7 @@ package org.cyclonedx.generators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.cyclonedx.CycloneDxSchema;
+import org.cyclonedx.Format;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.util.serializer.CustomSerializerModifier;
@@ -24,10 +25,19 @@ public abstract class AbstractBomGenerator extends CycloneDxSchema
 
   protected Bom bom;
 
-  public AbstractBomGenerator(final Version version, final Bom bom) {
+  protected Format format;
+
+  public AbstractBomGenerator(final Version version, final Bom bom, final Format format) {
     this.mapper = new ObjectMapper();
     this.version = version;
     this.bom = bom;
+    this.format = format;
+
+    if (!version.getFormats().contains(format)) {
+      throw new IllegalArgumentException(
+              "CycloneDX version " + version.getVersionString() + " does not support the " + format + " format"
+      );
+    }
   }
 
   /**
@@ -36,6 +46,14 @@ public abstract class AbstractBomGenerator extends CycloneDxSchema
    */
   public Version getSchemaVersion() {
     return version;
+  }
+
+  /**
+   * Returns the format that this generator creates.
+   * @return a Format enum
+   */
+  public Format getFormat() {
+    return format;
   }
 
   protected void setupObjectMapper(boolean isXml) {

--- a/src/main/java/org/cyclonedx/generators/BomGeneratorFactory.java
+++ b/src/main/java/org/cyclonedx/generators/BomGeneratorFactory.java
@@ -18,12 +18,24 @@
  */
 package org.cyclonedx.generators;
 
+import org.cyclonedx.Format;
 import org.cyclonedx.Version;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 
 public class BomGeneratorFactory {
+    public static AbstractBomGenerator create(Version version, Bom bom, Format format) {
+        AbstractBomGenerator generator;
+
+        switch (format) {
+            case XML: generator = createXml(version, bom); break;
+            case JSON: generator = createJson(version, bom); break;
+            default: throw new IllegalArgumentException("Unsupported format " + format);
+        }
+
+        return generator;
+    }
 
     public static BomXmlGenerator createXml(Version version, Bom bom) {
         return new BomXmlGenerator(bom, version);

--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.cyclonedx.Format;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.generators.AbstractBomGenerator;
@@ -46,7 +47,7 @@ public class BomJsonGenerator extends AbstractBomGenerator
    * @param bom the BOM to generate
    */
   public BomJsonGenerator(Bom bom, final Version version) {
-    super(version, bom);
+    super(version, bom, Format.JSON);
     Bom modifiedBom = null;
     try {
       modifiedBom = injectBomFormatAndSpecVersion(bom);

--- a/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.util.DefaultXmlPrettyPrinter;
+import org.cyclonedx.Format;
 import org.cyclonedx.generators.AbstractBomGenerator;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.GeneratorException;
@@ -49,7 +50,7 @@ public class BomXmlGenerator extends AbstractBomGenerator
      * @param bom the BOM to generate
      */
     public BomXmlGenerator(final Bom bom, final Version version) {
-        super(version, bom);
+        super(version, bom, Format.XML);
 
         mapper = new XmlMapper();
         prettyPrinter = new DefaultXmlPrettyPrinter();

--- a/src/main/java/org/cyclonedx/parsers/JsonParser.java
+++ b/src/main/java/org/cyclonedx/parsers/JsonParser.java
@@ -24,6 +24,7 @@ import com.networknt.schema.ValidationMessage;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.cyclonedx.CycloneDxSchema;
+import org.cyclonedx.Format;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
@@ -171,10 +172,19 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      */
     public List<ParseException> validate(final JsonNode bomJson, final Version schemaVersion) throws IOException {
         final List<ParseException> exceptions = new ArrayList<>();
+
+        if (!schemaVersion.getFormats().contains(Format.JSON)) {
+            exceptions.add(
+                    new ParseException("CycloneDX version " + schemaVersion.getVersionString() +
+                            " does not support the JSON format")
+            );
+        }
+
         Set<ValidationMessage> errors = getJsonSchema(schemaVersion, mapper).validate(mapper.readTree(bomJson.toString()));
         for (ValidationMessage message: errors) {
             exceptions.add(new ParseException(message.getMessage()));
         }
+
         return exceptions;
     }
 

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -49,11 +49,7 @@ import java.util.ArrayList;
 import java.util.stream.Stream;
 import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BomJsonGeneratorTest {
 
@@ -69,6 +65,16 @@ public class BomJsonGeneratorTest {
     public void after() {
         tempFile.delete();
         tempFile.getParentFile().delete();
+    }
+
+    @Test
+    public void testGenerateBomPrior12() {
+        Throwable exception = assertThrowsExactly(
+                IllegalArgumentException.class,
+                () -> new BomJsonGenerator(new Bom(), Version.VERSION_11)
+        );
+
+        assertEquals("CycloneDX version 1.1 does not support the JSON format", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/org/cyclonedx/parse/BaseParseTest.java
+++ b/src/test/java/org/cyclonedx/parse/BaseParseTest.java
@@ -18,6 +18,7 @@
  */
 package org.cyclonedx.parse;
 
+import org.cyclonedx.Format;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.cyclonedx.CycloneDxSchema;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public abstract class BaseParseTest {
 
@@ -61,7 +63,11 @@ public abstract class BaseParseTest {
     }
 
     void generateBomXml(final String testName, final Bom bom) throws ParserConfigurationException {
-        for (Version version : CycloneDxSchema.ALL_VERSIONS) {
+        List<Version> xmlVersions = Arrays.stream(Version.values())
+                .filter(v -> v.getFormats().contains(Format.XML))
+                .collect(Collectors.toList());
+
+        for (Version version : xmlVersions) {
             System.out.println("Generating CycloneDX " + version.getVersionString() + " XML for " + testName);
             BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
             Document doc = generator.generate();
@@ -70,7 +76,11 @@ public abstract class BaseParseTest {
     }
 
     void generateBomJson(final String testName, final Bom bom) {
-        for (Version version : CycloneDxSchema.ALL_VERSIONS) {
+        List<Version> jsonVersions = Arrays.stream(Version.values())
+                .filter(v -> v.getFormats().contains(Format.JSON))
+                .collect(Collectors.toList());
+
+        for (Version version : jsonVersions) {
             System.out.println("Generating CycloneDX " + version.getVersionString() + " JSON for " + testName);
             BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
             Assertions.assertNotNull(generator.toJsonString());

--- a/src/test/java/org/cyclonedx/parse/JsonParseTest.java
+++ b/src/test/java/org/cyclonedx/parse/JsonParseTest.java
@@ -18,14 +18,18 @@
  */
 package org.cyclonedx.parse;
 
+import org.cyclonedx.Version;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.parsers.JsonParser;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.io.IOException;
+import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JsonParseTest extends BaseParseTest {
@@ -51,4 +55,15 @@ public class JsonParseTest extends BaseParseTest {
         return dynamicTests;
     }
 
+    @Test
+    public void testValidateBomPrior12() throws IOException {
+        final JsonParser parser = new JsonParser();
+
+        final List<ParseException> exceptions = parser.validate("", Version.VERSION_11);
+
+        assertThat(exceptions.stream().map(ParseException::getMessage)).containsExactly(
+                "CycloneDX version 1.1 does not support the JSON format",
+                "$: unknown found, object expected"
+        );
+    }
 }


### PR DESCRIPTION
This allows things like iterating over the supported file formats for a given version, and generating all BOM file formats for it.