### PR TITLE
Make Vulnerability objects comparable by value

### DIFF
--- a/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
+++ b/src/main/java/org/cyclonedx/model/vulnerability/Vulnerability.java
@@ -21,6 +21,7 @@ package org.cyclonedx.model.vulnerability;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -29,11 +30,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import org.cyclonedx.model.OrganizationalContact;
-import org.cyclonedx.model.OrganizationalEntity;
-import org.cyclonedx.model.Property;
-import org.cyclonedx.model.Tool;
-import org.cyclonedx.model.VersionFilter;
+import org.cyclonedx.model.*;
 import org.cyclonedx.util.serializer.CustomDateSerializer;
 
 /**
@@ -276,6 +273,56 @@ public class Vulnerability
     this.properties = properties;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Vulnerability)) return false;
+    Vulnerability rhs = (Vulnerability) o;
+    return Objects.equals(bomRef, rhs.bomRef) &&
+            Objects.equals(id, rhs.id) &&
+            Objects.equals(source, rhs.source) &&
+            Objects.equals(references, rhs.references) &&
+            Objects.equals(ratings, rhs.ratings) &&
+            Objects.equals(cwes, rhs.cwes) &&
+            Objects.equals(description, rhs.description) &&
+            Objects.equals(detail, rhs.detail) &&
+            Objects.equals(recommendation, rhs.recommendation) &&
+            Objects.equals(advisories, rhs.advisories) &&
+            Objects.equals(created, rhs.created) &&
+            Objects.equals(published, rhs.published) &&
+            Objects.equals(updated, rhs.updated) &&
+            Objects.equals(rejected, rhs.rejected) &&
+            Objects.equals(credits, rhs.credits) &&
+            Objects.equals(tools, rhs.tools) &&
+            Objects.equals(analysis, rhs.analysis) &&
+            Objects.equals(affects, rhs.affects) &&
+            Objects.equals(properties, rhs.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+            bomRef,
+            id,
+            source,
+            references,
+            ratings,
+            cwes,
+            description,
+            detail,
+            recommendation,
+            advisories,
+            created,
+            published,
+            updated,
+            rejected,
+            credits,
+            tools,
+            analysis,
+            affects,
+            properties);
+  }
+
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class Reference {
     private String id;
@@ -295,6 +342,22 @@ public class Vulnerability
 
     public void setSource(final Source source) {
       this.source = source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Reference)) return false;
+      Reference rhs = (Reference) o;
+      return Objects.equals(id, rhs.id) &&
+              Objects.equals(source, rhs.source);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              id,
+              source);
     }
   }
 
@@ -318,6 +381,22 @@ public class Vulnerability
     public void setUrl(final String url) {
       this.url = url;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Source)) return false;
+      Source rhs = (Source) o;
+      return Objects.equals(name, rhs.name) &&
+              Objects.equals(url, rhs.url);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              name,
+              url);
+    }
   }
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -339,6 +418,22 @@ public class Vulnerability
 
     public void setUrl(final String url) {
       this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Advisory)) return false;
+      Advisory rhs = (Advisory) o;
+      return Objects.equals(title, rhs.title) &&
+              Objects.equals(url, rhs.url);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              title,
+              url);
     }
   }
 
@@ -473,6 +568,30 @@ public class Vulnerability
 
     public void setJustification(final String justification) {
       this.justification = justification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Rating)) return false;
+      Rating rhs = (Rating) o;
+      return Objects.equals(source, rhs.source) &&
+              Objects.equals(score, rhs.score) &&
+              Objects.equals(severity, rhs.severity) &&
+              Objects.equals(method, rhs.method) &&
+              Objects.equals(vector, rhs.vector) &&
+              Objects.equals(justification, rhs.justification);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              source,
+              score,
+              severity,
+              method,
+              vector,
+              justification);
     }
   }
 
@@ -655,6 +774,30 @@ public class Vulnerability
     public void setLastUpdated(final Date lastUpdated) {
       this.lastUpdated = lastUpdated;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Analysis)) return false;
+      Analysis rhs = (Analysis) o;
+      return Objects.equals(state, rhs.state) &&
+              Objects.equals(justification, rhs.justification) &&
+              Objects.equals(responses, rhs.responses) &&
+              Objects.equals(detail, rhs.detail) &&
+              Objects.equals(firstIssued, rhs.firstIssued) &&
+              Objects.equals(lastUpdated, rhs.lastUpdated);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              state,
+              justification,
+              responses,
+              detail,
+              firstIssued,
+              lastUpdated);
+    }
   }
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -678,6 +821,22 @@ public class Vulnerability
 
     public void setVersions(final List<Version> versions) {
       this.versions = versions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Affect)) return false;
+      Affect rhs = (Affect) o;
+      return Objects.equals(ref, rhs.ref) &&
+              Objects.equals(versions, rhs.versions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              ref,
+              versions);
     }
   }
 
@@ -766,6 +925,22 @@ public class Vulnerability
 
     public void setOrganizations(final List<OrganizationalEntity> organizations) {
       this.organizations = organizations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Credits)) return false;
+      Credits rhs = (Credits) o;
+      return Objects.equals(organizations, rhs.organizations) &&
+              Objects.equals(individuals, rhs.individuals);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+              organizations,
+              individuals);
     }
   }
 }


### PR DESCRIPTION
Enables comparison of two Vulnerability objects by their fields' values.

Implements #463

