### PR TITLE
Fix apidocs path for doc publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,4 +28,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29 # tag=v4.6.8
         with:
           branch: gh-pages
-          folder: target/apidocs
+          folder: target/reports/apidocs


### PR DESCRIPTION
The workflow is currently failing (e.g. https://github.com/CycloneDX/cyclonedx-core-java/actions/runs/11255965552/job/31296724337) because apidocs have moved from `target/apidocs` to `target/reports/apidocs`.