### PR TITLE
feat: enhance enums to have from*(String) methods

### DIFF
--- a/src/main/java/org/cyclonedx/Format.java
+++ b/src/main/java/org/cyclonedx/Format.java
@@ -30,4 +30,20 @@ public enum Format {
     public String getMediaType() {
         return mediaType;
     }
+
+    /**
+     * Returns the format based on the given file extension.
+     *
+     * @param extension The file extension.
+     * @return The format or null if not found.
+     */
+    public static Format fromExtension(String extension) {
+        if (extension != null) {
+            switch (extension) {
+                case "xml": return XML;
+                case "json": return JSON;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/cyclonedx/Version.java
+++ b/src/main/java/org/cyclonedx/Version.java
@@ -44,4 +44,25 @@ public enum Version
     this.version = version;
     this.formats = formats;
   }
+
+  /**
+   * Returns the version based on the given version string.
+   *
+   * @param versionString The version string.
+   * @return The version or null if not found.
+   */
+  public static Version fromVersionString(String versionString) {
+    if (versionString != null) {
+      switch (versionString) {
+        case "1.0": return VERSION_10;
+        case "1.1": return VERSION_11;
+        case "1.2": return VERSION_12;
+        case "1.3": return VERSION_13;
+        case "1.4": return VERSION_14;
+        case "1.5": return VERSION_15;
+        case "1.6": return VERSION_16;
+      }
+    }
+    return null;
+  }
 }

--- a/src/test/java/org/cyclonedx/FormatTest.java
+++ b/src/test/java/org/cyclonedx/FormatTest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FormatTest {
+
+    @Test
+    void testFromExtension() {
+        for (Format format : Format.values()) {
+            String extension = format.getExtension();
+            Format result = Format.fromExtension(extension);
+            assertEquals(format, result, () -> "Format should match for extension " + extension);
+        }
+    }
+
+    @Test
+    void testFromExtensionInvalid() {
+        Format result = Format.fromExtension("invalid-extension");
+        assertNull(result);
+    }
+
+    @Test
+    void testFromExtensionNull() {
+        Format result = Format.fromExtension(null);
+        assertNull(result);
+    }
+}

--- a/src/test/java/org/cyclonedx/VersionTest.java
+++ b/src/test/java/org/cyclonedx/VersionTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class VersionTest {
+
+    /**
+     * Test the getVersionString method - this is to ensure the method is future-proof.
+     * If a new enum value is added this test will fail unless fromVersionString is updated.
+     */
+    @Test
+    void testFromVersionString() {
+        for (Version version : Version.values()) {
+            String versionString = version.getVersionString();
+            Version result = Version.fromVersionString(versionString);
+            assertEquals(version, result, () -> "Version should match for " + versionString);
+        }
+    }
+
+    @Test
+    void testFromVersionStringInvalid() {
+        Version result = Version.fromVersionString("invalid-version");
+        assertNull(result);
+    }
+    @Test
+    void testFromVersionStringNull() {
+        Version result = Version.fromVersionString(null);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
`Version` and `Format` should have `from*(String)` methods to allow conversion from String values to the enum values.