### PR TITLE
Allow to specify prettyPrint for toJsonString method

### DIFF
--- a/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/json/BomJsonGenerator.java
@@ -119,6 +119,10 @@ public class BomJsonGenerator extends AbstractBomGenerator
       return toJson(bom, true);
   }
 
+  public String toJsonString(boolean prettyPrint) throws GeneratorException {
+    return toJson(bom, prettyPrint);
+  }
+
   /**
    * Creates a text representation of a CycloneDX BoM Document. This method calls {@link #toJsonString()} and will return
    * an empty string if {@link #toJsonString()} throws an exception. It's preferred to call {@link #toJsonString()}


### PR DESCRIPTION
This add a new method that allows prettyPrint to be specified when using the `toJsonString` method, now it's always true by default.