### PR TITLE
Better separation of tests depending on specific Java versions

### DIFF
--- a/src/test/java/org/cyclonedx/util/BomUtilsTest.java
+++ b/src/test/java/org/cyclonedx/util/BomUtilsTest.java
@@ -18,14 +18,15 @@
  */
 package org.cyclonedx.util;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Hash;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
 import java.io.File;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -44,7 +45,7 @@ import static org.cyclonedx.model.Hash.Algorithm.SHA_512;
 public class BomUtilsTest {
 
     @Test
-    public void calculateHashesTest() throws Exception {
+    public void calculateHashes() throws Exception {
         final File file = new File(Objects.requireNonNull(this.getClass().getResource("/hashtest.txt")).toURI());
 
         final List<Hash> hashes = BomUtils.calculateHashes(file, Version.VERSION_12);
@@ -54,15 +55,23 @@ public class BomUtilsTest {
         assertThatHashIsComputed(hashes, SHA_256, "c87e2ca771bab6024c269b933389d2a92d4941c848c52f155b9b84e1f109fe35");
         assertThatHashIsComputed(hashes, SHA_384, "1600a408df6f0775d5d3d2f13d8355a7a668ffc1be13810041e883f510b05dba0662a55c0b6b9a49c51293fa892d00d7");
         assertThatHashIsComputed(hashes, SHA_512, "3de78a913cb8896f8f08ce3374b726b49ed00cc569621c5161c31eb80fca4d2f5e4443d42676dfc79743f345de7f0b95dbb2c97b2bc1a438a5a49c5f1b5298ac");
-        if (supportsSha3Algorithms()) {
-            assertThatHashIsComputed(hashes, SHA3_256, "d79acc39c4f826d0a0abb614866b0347ab7a782473f666fa49582cec7acb57c6");
-            assertThatHashIsComputed(hashes, SHA3_384, "c557b693f910c4cab2ca5ba55083bbe08a1362038c8217179955af7686ae79f3547e383d0d63cca5e85240aed7fe8c0b");
-            assertThatHashIsComputed(hashes, SHA3_512, "6a2825f3e8889f60ba965894a15d09b7f3958e0bd896ad293d3a04cda2cfa1aa9764567da61a62b4af55191d1108d9ca8b9e926411c9adc2d7b0f35f6fb11633");
-        }
     }
 
     @Test
-    public void calculateHashesForBigFileTest() throws Exception {
+    @EnabledForJreRange(min = JRE.JAVA_17)
+    public void calculateSha3HashesOnJava17AndHigher() throws Exception {
+        final File file = new File(Objects.requireNonNull(this.getClass().getResource("/hashtest.txt")).toURI());
+
+        final List<Hash> hashes = BomUtils.calculateHashes(file, Version.VERSION_12);
+
+        assertThatHashIsComputed(hashes, SHA3_256, "d79acc39c4f826d0a0abb614866b0347ab7a782473f666fa49582cec7acb57c6");
+        assertThatHashIsComputed(hashes, SHA3_384, "c557b693f910c4cab2ca5ba55083bbe08a1362038c8217179955af7686ae79f3547e383d0d63cca5e85240aed7fe8c0b");
+        assertThatHashIsComputed(hashes, SHA3_512, "6a2825f3e8889f60ba965894a15d09b7f3958e0bd896ad293d3a04cda2cfa1aa9764567da61a62b4af55191d1108d9ca8b9e926411c9adc2d7b0f35f6fb11633");
+    }
+
+
+    @Test
+    public void calculateHashesForBigFile() throws Exception {
         final File file = generateBigFileWithReproductiveContent();
 
         final List<Hash> hashes = BomUtils.calculateHashes(file, Version.VERSION_12);
@@ -72,12 +81,18 @@ public class BomUtilsTest {
         assertThatHashIsComputed(hashes, SHA_256, "0d797f9a8794ff2a00be343e012403620750609067bbf5899c340959159b86b3");
         assertThatHashIsComputed(hashes, SHA_384, "be5785a76b67105066f65fa9d2f85bd5f438149396eb039a4a89d1ae0822de34bd6502f242de992d29a253d3e5093001");
         assertThatHashIsComputed(hashes, SHA_512, "fed86c6ab6b75f044dd0aa8bc60468d4070cf081e26040daf61fd0d4c1d74ff6cead44b32b258483041d11eac6b80edafa2d5a0d0d59d5d7e750f775feac01f2");
+    }
 
-        if (supportsSha3Algorithms()) {
-            assertThatHashIsComputed(hashes, SHA3_256, "6afc5eea1405183f2a273deb87795bbdabfa9a23c07ec56b080b29f9a357931e");
-            assertThatHashIsComputed(hashes, SHA3_384, "3bebb987e764240cca59e03f29d0c6f38221fa01295b84e0fe85e8057220f0ac173171c9a5ded67ef9b109cb63f12e51");
-            assertThatHashIsComputed(hashes, SHA3_512, "eec26946678ae2d09db65ac618f4ddf150c517c06864296eeb5f9dc6138bf695341353527c058cf82eb6a8bacd8907ef1494c108c71f2f31f201ef521c6991ea");
-        }
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_17)
+    public void calculateSha3HashesForBigFileOnJava17AndHigher() throws Exception {
+        final File file = generateBigFileWithReproductiveContent();
+
+        final List<Hash> hashes = BomUtils.calculateHashes(file, Version.VERSION_12);
+
+        assertThatHashIsComputed(hashes, SHA3_256, "6afc5eea1405183f2a273deb87795bbdabfa9a23c07ec56b080b29f9a357931e");
+        assertThatHashIsComputed(hashes, SHA3_384, "3bebb987e764240cca59e03f29d0c6f38221fa01295b84e0fe85e8057220f0ac173171c9a5ded67ef9b109cb63f12e51");
+        assertThatHashIsComputed(hashes, SHA3_512, "eec26946678ae2d09db65ac618f4ddf150c517c06864296eeb5f9dc6138bf695341353527c058cf82eb6a8bacd8907ef1494c108c71f2f31f201ef521c6991ea");
     }
 
     private void assertThatHashIsComputed(final List<Hash> hashes, final Hash.Algorithm algorithm, final String expectedHashValue) {
@@ -102,18 +117,4 @@ public class BomUtilsTest {
         }
         return file;
     }
-
-    /** Need to run these tests with JDK17 (for eg.ie. not JDK8) in order to have SHA3 algorithms support */
-    static boolean supportsSha3Algorithms() {
-        try {
-            DigestUtils.getSha3_256Digest().update(new byte []{1});
-            return true;
-        } catch (IllegalArgumentException e) {
-            if (e.getCause() instanceof NoSuchAlgorithmException) {
-                return false;
-            }
-            throw e;
-        }
-    }
-
 }


### PR DESCRIPTION
Version dependent tests should not rely on if-protected blocks, but rather declare this via JUnit Jupiter annotations. Therefore split the previous 2 tests into 4 tests.