### PR TITLE
Bump version to `11.0.0-SNAPSHOT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-core-java</artifactId>
     <packaging>jar</packaging>
-    <version>10.2.2-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>CycloneDX Core (Java)</name>
     <description>The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.</description>


### PR DESCRIPTION
A major version bump is necessary due to a breaking change introduced via #628