### PR TITLE
Use Maven BOM for Jackson and JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,26 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.19.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.13.4</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Apache Commons -->
         <dependency>
@@ -181,7 +201,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.19.1</version>
         </dependency>
 
         <!-- JSON Schema library -->
@@ -204,14 +223,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This ensures that all versions of each respective library ecosystem stay consistent.

In the case of Jackson, we previously had a mixture of 2.18.x and 2.19.x.

Supersedes https://github.com/CycloneDX/cyclonedx-core-java/pull/665
Supersedes https://github.com/CycloneDX/cyclonedx-core-java/pull/666
Supersedes https://github.com/CycloneDX/cyclonedx-core-java/pull/667