### PR TITLE
feat: Add `GPL v2 with the Classpath exception`

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -175,7 +175,8 @@
       "GPLv2 with classpath exception",
       "GPLv2 license, includes the CLASSPATH exception",
       "GNU General Public License, version 2, with the Classpath Exception",
-      "GNU General Public License, version 2 with the GNU Classpath Exception"
+      "GNU General Public License, version 2 with the GNU Classpath Exception",
+      "GPL v2 with the Classpath exception"
     ]
   },
   {


### PR DESCRIPTION
This is the license name used by Nashorn: https://github.com/openjdk/nashorn/pull/27