### PR TITLE
feat: Alias `Bouncy Castle Licence` to `MIT`

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -249,7 +249,8 @@
     "names": [
       "MIT License",
       "The MIT License",
-      "The MIT License (MIT)"
+      "The MIT License (MIT)",
+      "Bouncy Castle Licence"
     ]
   },
   {


### PR DESCRIPTION
Per SPDX the license is equivalent to MIT: https://github.com/spdx/license-list-XML/issues/910#issuecomment-518336341

Fixes #643
