### PR TITLE
Added mapping for CPL license

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -305,5 +305,11 @@
     "names": [
       "The W3C Software License"
     ]
+  },
+  {
+    "exp": "CPL-1.0",
+    "names": [
+      "CPL"
+    ]
   }
 ]


### PR DESCRIPTION
Added mapping for CPL license, that is used by wsdl4j:1.6.3