### PR TITLE
Adjust release process for new Maven Central publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           # Export the gpg private key using the following command and add the contents of that file to the GitHub secret
           # gpg --armor --export-secret-keys <key_id> > gpg_key.asc
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -39,27 +39,23 @@ jobs:
         run: |
           git config --global user.email "info@cyclonedx.org"
           git config --global user.name "CycloneDX Automation"
-          git config --global credential.helper 'store --file ~/.git-credentials'
-          echo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com" > ~/.git-credentials
 
       - name: Set Maven options
         id: maven_options
         run: |
           # Set the Maven options based on the 'dry_run' input
           if ${{ github.event.inputs.dry_run }}; then
-            echo "options=release:prepare -DdryRun=true -Prelease" >> $GITHUB_ENV
+            echo "options=release:prepare -DdryRun=true" >> $GITHUB_ENV
           else
-            echo "options=release:clean release:prepare release:perform -Prelease" >> $GITHUB_ENV
+            echo "options=release:clean release:prepare release:perform" >> $GITHUB_ENV
           fi
 
       - name: Run Maven command
-        # This requires the connection and developerConnection elements in the scm section of the pom
-        # to be set to "scm:git:https:...." thus preventing the release plugin from using SSH.
         run: |
           mvn -B ${{ env.options }}
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: ${{ github.event.inputs.dry_run == false }}
@@ -70,7 +66,7 @@ jobs:
           echo "Release failed. Rolling back..."
           mvn -B release:rollback -Prelease
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,18 @@
         <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
         <maven.github.release.plugin.version>1.6.0</maven.github.release.plugin.version>
         <project.build.outputTimestamp>2025-03-12T01:44:22Z</project.build.outputTimestamp>
+
+        <!-- Default SCM Properties -->
+        <scm.connection>scm:git:https://github.com/CycloneDX/cyclonedx-core-java.git</scm.connection>
+        <scm.developerConnection>scm:git:https://github.com/CycloneDX/cyclonedx-core-java.git</scm.developerConnection>
+        <scm.url>https://github.com/CycloneDX/cyclonedx-core-java.git</scm.url>
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/CycloneDX/cyclonedx-core-java.git</connection>
-        <url>https://github.com/CycloneDX/cyclonedx-core-java.git</url>
-        <developerConnection>scm:git:https://github.com/CycloneDX/cyclonedx-core-java.git</developerConnection>
+        <connection>${scm.connection}</connection>
+        <developerConnection>${scm.developerConnection}</developerConnection>
         <tag>HEAD</tag>
+        <url>${scm.url}</url>
     </scm>
 
     <issueManagement>
@@ -101,48 +106,6 @@
         <system>GitHub</system>
         <url>https://github.com/CycloneDX/cyclonedx-core-java/actions</url>
     </ciManagement>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
-    <repositories>
-        <repository>
-            <id>maven-central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <!-- Resolve snapshot releases -->
-        <repository>
-            <id>ossrh-snapshot</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <updatePolicy>always</updatePolicy>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>ossrh-snapshot</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <updatePolicy>always</updatePolicy>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <updatePolicy>always</updatePolicy>
-                <enabled>true</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>
@@ -298,19 +261,25 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>de.jutzig</groupId>
-                <artifactId>github-release-plugin</artifactId>
-                <version>${maven.github.release.plugin.version}</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
-                    <tag>${project.artifactId}-${project.version}</tag>
-                    <fileSets>
-                        <fileSet>
-                            <directory>${project.build.directory}</directory>
-                            <includes>
-                                <include>${project.build.finalName}.jar</include>
-                            </includes>
-                        </fileSet>
-                    </fileSets>
+                    <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+                    <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <autoPublish>true</autoPublish>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>
@@ -336,6 +305,27 @@
     </build>
 
     <profiles>
+        <profile>
+            <!--
+              When running in GitHub Actions, the SCM connection must be via HTTPS
+              so that the GITHUB_TOKEN injected by Actions can be used to authenticate.
+
+              Connection URLs target the repository for which the Actions workflow is
+              running, enabling the release process to be tested in forks.
+            -->
+            <id>github-actions</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <scm.connection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.connection>
+                <scm.developerConnection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.developerConnection>
+                <scm.url>https://github.com/${env.GITHUB_REPOSITORY}.git</scm.url>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <activation>


### PR DESCRIPTION
Adjusts the release process for new Maven Central publishing.

@stevespringett, please generate a username and token as outlined [here](https://central.sonatype.org/publish/generate-portal-token/), and configure them as secrets for GitHub Actions.

Please also enable `SNAPSHOT` publishing for the namespace as described [here](https://central.sonatype.org/publish/publish-portal-snapshots/#enabling-snapshot-releases-for-your-namespace).