### PR TITLE
New Apache 2.0 mapping for license resolution

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -14,6 +14,7 @@
       "Apache 2.0",
       "Apache 2.0 License",
       "Apache Software License, Version 2.0",
+      "Apache Software License 2.0",
       "The Apache Software License, Version 2.0",
       "Apache License (v2.0)",
       "Apache License 2.0",


### PR DESCRIPTION
"Apache Software License 2.0" as a license name occurs e.g. in the [HAPI FHIR Java Project (Java API for HL7 FHIR Clients and Servers)](https://github.com/hapifhir/hapi-fhir) and can't be currently resolved to the Apache 2.0 license. The Pull Requests adds a corresponding mapping