### PR TITLE
Lower Java baseline to 8 again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Maven Plugin Versions -->


### PR DESCRIPTION
Addresses the concern of legacy projects relying on this library being left behind.

Note that tests are still compiled for Java 17, which allows us to use convenience features such as text blocks, and use up-to-date library versions at least for the test side of things.

Closes https://github.com/CycloneDX/cyclonedx-core-java/issues/799