### PR TITLE
Support patents and version-aware serialization

### DIFF
--- a/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/AbstractBomGenerator.java
@@ -64,7 +64,7 @@ public abstract class AbstractBomGenerator extends CycloneDxSchema
     mapper.registerModule(licenseModule);
 
     SimpleModule lifecycleModule = new SimpleModule();
-    lifecycleModule.addSerializer(new LifecycleSerializer(isXml));
+    lifecycleModule.addSerializer(new LifecycleSerializer(isXml, version));
     mapper.registerModule(lifecycleModule);
 
     SimpleModule metadataModule = new SimpleModule();
@@ -76,11 +76,11 @@ public abstract class AbstractBomGenerator extends CycloneDxSchema
     mapper.registerModule(vulnerabilityModule);
 
     SimpleModule inputTypeModule = new SimpleModule();
-    inputTypeModule.addSerializer(new InputTypeSerializer(isXml));
+    inputTypeModule.addSerializer(new InputTypeSerializer(isXml, version));
     mapper.registerModule(inputTypeModule);
 
     SimpleModule outputTypeModule = new SimpleModule();
-    outputTypeModule.addSerializer(new OutputTypeSerializer(isXml));
+    outputTypeModule.addSerializer(new OutputTypeSerializer(isXml, version));
     mapper.registerModule(outputTypeModule);
 
     SimpleModule evidenceModule = new SimpleModule();

--- a/src/main/java/org/cyclonedx/model/Component.java
+++ b/src/main/java/org/cyclonedx/model/Component.java
@@ -54,7 +54,9 @@ import org.cyclonedx.util.deserializer.PropertiesDeserializer;
 @JsonPropertyOrder(
     {
      "type",
+     "mime-type",
      "bom-ref",
+     "isExternal",
      "supplier",
      "manufacturer",
      "authors",
@@ -63,11 +65,13 @@ import org.cyclonedx.util.deserializer.PropertiesDeserializer;
      "group",
      "name",
      "version",
+     "versionRange",
      "description",
      "scope",
      "hashes",
      "licenses",
      "copyright",
+     "patentAssertions",
      "cpe",
      "purl",
      "omniborId",
@@ -83,6 +87,7 @@ import org.cyclonedx.util.deserializer.PropertiesDeserializer;
      "modelCard",
      "data",
      "cryptoProperties",
+     "tags",
      "signature",
      "provides"
     })
@@ -95,22 +100,29 @@ public class Component extends ExtensibleElement {
         FRAMEWORK("framework"),
         @JsonProperty("library")
         LIBRARY("library"),
+        @VersionFilter(Version.VERSION_12)
         @JsonProperty("container")
         CONTAINER("container"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("platform")
         PLATFORM("platform"),
         @JsonProperty("operating-system")
         OPERATING_SYSTEM("operating-system"),
         @JsonProperty("device")
         DEVICE("device"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("device-driver")
         DEVICE_DRIVER("device-driver"),
+        @VersionFilter(Version.VERSION_12)
         @JsonProperty("firmware")
         FIRMWARE("firmware"),
+        @VersionFilter(Version.VERSION_11)
         @JsonProperty("file")
         FILE("file"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("machine-learning-model")
         MACHINE_LEARNING_MODEL("machine-learning-model"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("data")
         DATA("data"),
         @VersionFilter(Version.VERSION_16)
@@ -133,6 +145,7 @@ public class Component extends ExtensibleElement {
         REQUIRED("required"),
         @JsonProperty("optional")
         OPTIONAL("optional"),
+        @VersionFilter(Version.VERSION_12)
         @JsonProperty("excluded")
         EXCLUDED("excluded");
 
@@ -171,7 +184,6 @@ public class Component extends ExtensibleElement {
     @VersionFilter(Version.VERSION_12)
     private String author;
 
-    @VersionFilter(Version.VERSION_11)
     private String publisher;
     private String group;
     private String name;

--- a/src/main/java/org/cyclonedx/model/Composition.java
+++ b/src/main/java/org/cyclonedx/model/Composition.java
@@ -43,14 +43,18 @@ public class Composition {
         INCOMPLETE("incomplete"),
         @JsonProperty("incomplete_first_party_only")
         INCOMPLETE_FIRST_PARTY_ONLY("incomplete_first_party_only"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("incomplete_first_party_proprietary_only")
         INCOMPLETE_FIRST_PARTY_PROPRIETARY_ONLY("incomplete_first_party_proprietary_only"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("incomplete_first_party_opensource_only")
         INCOMPLETE_FIRST_PARTY_OPENSOURCE_ONLY("incomplete_first_party_opensource_only"),
         @JsonProperty("incomplete_third_party_only")
         INCOMPLETE_THIRD_PARTY_ONLY("incomplete_third_party_only"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("incomplete_third_party_proprietary_only")
         INCOMPLETE_THIRD_PARTY_PROPRIETARY_ONLY("incomplete_third_party_proprietary_only"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("incomplete_third_party_opensource_only")
         INCOMPLETE_THIRD_PARTY_OPENSOURCE_ONLY("incomplete_third_party_opensource_only"),
         @JsonProperty("unknown")

--- a/src/main/java/org/cyclonedx/model/ExternalReference.java
+++ b/src/main/java/org/cyclonedx/model/ExternalReference.java
@@ -56,10 +56,12 @@ public class ExternalReference {
         DOCUMENTATION("documentation"),
         @JsonProperty("support")
         SUPPORT("support"),
+        @VersionFilter(Version.VERSION_16)
         @JsonProperty("source-distribution")
         SOURCE_DISTRIBUTION("source-distribution"),
         @JsonProperty("distribution")
         DISTRIBUTION("distribution"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("distribution-intake")
         DISTRIBUTION_INTAKE("distribution-intake"),
         @JsonProperty("license")
@@ -68,51 +70,73 @@ public class ExternalReference {
         BUILD_META("build-meta"),
         @JsonProperty("build-system")
         BUILD_SYSTEM("build-system"),
+        @VersionFilter(Version.VERSION_14)
         @JsonProperty("release-notes")
         RELEASE_NOTES("release-notes"),
         @VersionFilter(Version.VERSION_15)
         @JsonProperty("security-contact")
         SECURITY_CONTACT("security-contact"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("model_card")
         MODEL_CARD("model_card"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("attestation")
         ATTESTATION("attestation"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("threat-model")
         THREAT_MODEL("threat-model"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("adversary-model")
         ADVERSARY_MODEL("adversary-model"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("risk-assessment")
         RISK_ASSESSMENT("risk-assessment"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("vulnerability-assertion")
         VULNERABILITY_ASSERTION("vulnerability-assertion"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("exploitability-statement")
         EXPLOITABILITY_STATEMENT("exploitability-statement"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("pentest-report")
         PENTEST_REPORT("pentest-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("static-analysis-report")
         STATIC_ANALYSIS_REPORT("static-analysis-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("dynamic-analysis-report")
         DYNAMIC_ANALYSIS_REPORT("dynamic-analysis-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("runtime-analysis-report")
         RUNTIME_ANALYSIS_REPORT("runtime-analysis-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("component-analysis-report")
         COMPONENT_ANALYSIS_REPORT("component-analysis-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("maturity-report")
         MATURITY_REPORT("maturity-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("certification-report")
         CERTIFICATION_REPORT("certification-report"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("codified-infrastructure")
         CODIFIED_INFRASTRUCTURE("codified-infrastructure"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("quality-metrics")
         QUALITY_METRICS("quality-metrics"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("log")
         LOG("log"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("configuration")
         CONFIGURATION("configuration"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("evidence")
         EVIDENCE("evidence"),
+        @VersionFilter(Version.VERSION_15)
         @JsonProperty("formulation")
         FORMULATION("formulation"),
+        @VersionFilter(Version.VERSION_16)
         @JsonProperty("rfc-9116")
         RFC_9116("rfc-9116"),
         @VersionFilter(Version.VERSION_16)

--- a/src/main/java/org/cyclonedx/model/LicenseItem.java
+++ b/src/main/java/org/cyclonedx/model/LicenseItem.java
@@ -20,6 +20,7 @@ package org.cyclonedx.model;
 
 import java.util.Objects;
 
+import org.cyclonedx.Version;
 import org.cyclonedx.model.license.Expression;
 import org.cyclonedx.model.license.ExpressionDetailed;
 
@@ -38,6 +39,7 @@ public class LicenseItem {
 
     private License license;
     private Expression expression;
+    @VersionFilter(Version.VERSION_17)
     private ExpressionDetailed expressionDetailed;
 
     /**

--- a/src/main/java/org/cyclonedx/model/Patent.java
+++ b/src/main/java/org/cyclonedx/model/Patent.java
@@ -23,10 +23,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import org.cyclonedx.util.serializer.CustomDateSerializer;
+import org.cyclonedx.util.serializer.OrganizationalChoiceSerializer;
 
 import java.util.Date;
 import java.util.List;
@@ -110,19 +111,20 @@ public class Patent extends ExtensibleElement {
     @JsonProperty("abstract")
     private String patentAbstract;
 
-    @JsonSerialize(using = CustomDateSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "UTC")
     private Date filingDate;
 
-    @JsonSerialize(using = CustomDateSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "UTC")
     private Date grantDate;
 
-    @JsonSerialize(using = CustomDateSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "UTC")
     private Date patentExpirationDate;
 
     private PatentLegalStatus patentLegalStatus;
 
-    @JacksonXmlElementWrapper(localName = "patentAssignee")
+    @JacksonXmlElementWrapper(useWrapping = false)
     @JacksonXmlProperty(localName = "patentAssignee")
+    @JsonSerialize(contentUsing = OrganizationalChoiceSerializer.class)
     private List<OrganizationalChoice> patentAssignee;
 
     @JacksonXmlElementWrapper(localName = "externalReferences")

--- a/src/main/java/org/cyclonedx/model/PatentAssertion.java
+++ b/src/main/java/org/cyclonedx/model/PatentAssertion.java
@@ -23,8 +23,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import org.cyclonedx.util.deserializer.PatentAssertionDeserializer;
+import org.cyclonedx.util.serializer.PatentAssertionSerializer;
 
 import java.util.List;
 import java.util.Objects;
@@ -36,7 +40,9 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-@JsonPropertyOrder({"bomRef", "assertionType", "patentRefs", "asserter", "notes"})
+@JsonPropertyOrder({"bom-ref", "assertionType", "patentRefs", "asserter", "notes"})
+@JsonDeserialize(using = PatentAssertionDeserializer.class)
+@JsonSerialize(using = PatentAssertionSerializer.class)
 public class PatentAssertion extends ExtensibleElement {
 
     public enum AssertionType {
@@ -96,7 +102,11 @@ public class PatentAssertion extends ExtensibleElement {
     }
 
     public void setBomRef(String bomRef) {
-        this.bomRef = bomRef;
+        // Guard against Jackson XML overwriting the attribute value when processing
+        // <bom-ref> child elements inside <patentRefs> (same local name conflict)
+        if (bomRef != null && !bomRef.isEmpty()) {
+            this.bomRef = bomRef;
+        }
     }
 
     public AssertionType getAssertionType() {

--- a/src/main/java/org/cyclonedx/model/PatentItem.java
+++ b/src/main/java/org/cyclonedx/model/PatentItem.java
@@ -1,0 +1,77 @@
+package org.cyclonedx.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.cyclonedx.util.deserializer.PatentItemDeserializer;
+import org.cyclonedx.util.serializer.PatentItemSerializer;
+
+import java.util.Objects;
+
+/**
+ * Discriminated union for the polymorphic patents array in definitions.
+ * Can hold either a {@link Patent} or a {@link PatentFamily}.
+ *
+ * @since 10.0.0
+ */
+@JsonDeserialize(using = PatentItemDeserializer.class)
+@JsonSerialize(using = PatentItemSerializer.class)
+public class PatentItem {
+
+    public enum Type {
+        PATENT,
+        PATENT_FAMILY
+    }
+
+    private Patent patent;
+    private PatentFamily patentFamily;
+
+    private PatentItem() {
+    }
+
+    public static PatentItem ofPatent(Patent patent) {
+        PatentItem item = new PatentItem();
+        item.patent = patent;
+        return item;
+    }
+
+    public static PatentItem ofPatentFamily(PatentFamily patentFamily) {
+        PatentItem item = new PatentItem();
+        item.patentFamily = patentFamily;
+        return item;
+    }
+
+    public Patent getPatent() {
+        return patent;
+    }
+
+    public PatentFamily getPatentFamily() {
+        return patentFamily;
+    }
+
+    @JsonIgnore
+    public Type getType() {
+        if (patent != null) return Type.PATENT;
+        if (patentFamily != null) return Type.PATENT_FAMILY;
+        return null;
+    }
+
+    @JsonIgnore
+    public boolean isValid() {
+        return patent != null || patentFamily != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PatentItem)) return false;
+        PatentItem that = (PatentItem) o;
+        return Objects.equals(patent, that.patent) &&
+            Objects.equals(patentFamily, that.patentFamily);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(patent, patentFamily);
+    }
+}

--- a/src/main/java/org/cyclonedx/model/PriorityApplication.java
+++ b/src/main/java/org/cyclonedx/model/PriorityApplication.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.cyclonedx.util.serializer.CustomDateSerializer;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.util.Date;
 import java.util.Objects;
@@ -40,7 +40,7 @@ public class PriorityApplication {
 
     private String applicationNumber;
     private String jurisdiction;
-    @JsonSerialize(using = CustomDateSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "UTC")
     private Date filingDate;
 
     public String getApplicationNumber() {

--- a/src/main/java/org/cyclonedx/model/Service.java
+++ b/src/main/java/org/cyclonedx/model/Service.java
@@ -90,6 +90,7 @@ public class Service extends ExtensibleElement {
     private List<PatentAssertion> patentAssertions;
 
     private List<Service> services;
+    @VersionFilter(Version.VERSION_14)
     private ReleaseNotes releaseNotes;
     @JsonOnly
     @VersionFilter(Version.VERSION_14)

--- a/src/main/java/org/cyclonedx/model/definition/Definition.java
+++ b/src/main/java/org/cyclonedx/model/definition/Definition.java
@@ -1,32 +1,36 @@
 package org.cyclonedx.model.definition;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Patent;
 import org.cyclonedx.model.PatentFamily;
+import org.cyclonedx.model.PatentItem;
 import org.cyclonedx.model.VersionFilter;
+import org.cyclonedx.util.deserializer.PatentsDeserializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({
-    "standards", "patents", "patentFamilies"
+    "standards", "patents"
 })
 public class Definition
 {
   private List<Standard> standards;
 
   @VersionFilter(Version.VERSION_17)
-  private List<Patent> patents;
-
-  @VersionFilter(Version.VERSION_17)
-  private List<PatentFamily> patentFamilies;
+  @JsonDeserialize(using = PatentsDeserializer.class)
+  private List<PatentItem> patents;
 
   @JacksonXmlElementWrapper(localName = "standards")
   @JacksonXmlProperty(localName = "standard")
@@ -41,23 +45,54 @@ public class Definition
   @JacksonXmlElementWrapper(localName = "patents")
   @JacksonXmlProperty(localName = "patent")
   @VersionFilter(Version.VERSION_17)
-  public List<Patent> getPatents() {
+  public List<PatentItem> getPatents() {
     return patents;
   }
 
-  public void setPatents(final List<Patent> patents) {
+  public void setPatents(final List<PatentItem> patents) {
     this.patents = patents;
   }
 
-  @JacksonXmlElementWrapper(useWrapping = false)
-  @JacksonXmlProperty(localName = "patentFamily")
-  @VersionFilter(Version.VERSION_17)
-  public List<PatentFamily> getPatentFamilies() {
-    return patentFamilies;
+  /**
+   * @deprecated Use {@link #getPatents()} and filter by type instead.
+   */
+  @Deprecated
+  @JsonIgnore
+  public List<Patent> getPatentList() {
+    if (patents == null) return null;
+    List<Patent> result = patents.stream()
+        .filter(item -> item.getPatent() != null)
+        .map(PatentItem::getPatent)
+        .collect(Collectors.toList());
+    return result.isEmpty() ? null : result;
   }
 
-  public void setPatentFamilies(final List<PatentFamily> patentFamilies) {
-    this.patentFamilies = patentFamilies;
+  /**
+   * @deprecated Use {@link #getPatents()} and filter by type instead.
+   */
+  @Deprecated
+  @JsonIgnore
+  public List<PatentFamily> getPatentFamilyList() {
+    if (patents == null) return null;
+    List<PatentFamily> result = patents.stream()
+        .filter(item -> item.getPatentFamily() != null)
+        .map(PatentItem::getPatentFamily)
+        .collect(Collectors.toList());
+    return result.isEmpty() ? null : result;
+  }
+
+  public void addPatent(Patent patent) {
+    if (this.patents == null) {
+      this.patents = new ArrayList<>();
+    }
+    this.patents.add(PatentItem.ofPatent(patent));
+  }
+
+  public void addPatentFamily(PatentFamily patentFamily) {
+    if (this.patents == null) {
+      this.patents = new ArrayList<>();
+    }
+    this.patents.add(PatentItem.ofPatentFamily(patentFamily));
   }
 
   @Override
@@ -70,12 +105,11 @@ public class Definition
     }
     Definition that = (Definition) object;
     return Objects.equals(standards, that.standards) &&
-        Objects.equals(patents, that.patents) &&
-        Objects.equals(patentFamilies, that.patentFamilies);
+        Objects.equals(patents, that.patents);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(standards, patents, patentFamilies);
+    return Objects.hash(standards, patents);
   }
 }

--- a/src/main/java/org/cyclonedx/model/definition/Level.java
+++ b/src/main/java/org/cyclonedx/model/definition/Level.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 @JsonPropertyOrder({
     "identifier",
     "title",
-    "text",
     "description",
     "requirements"
 })

--- a/src/main/java/org/cyclonedx/model/formulation/FormulationCommon.java
+++ b/src/main/java/org/cyclonedx/model/formulation/FormulationCommon.java
@@ -155,8 +155,8 @@ public abstract class FormulationCommon extends BasicDataAbstract
     COPY("copy"),
     @JsonProperty("clone")
     CLONE("clone"),
-    @JsonProperty("LINT")
-    LINT("LINT"),
+    @JsonProperty("lint")
+    LINT("lint"),
     @JsonProperty("scan")
     SCAN("scan"),
     @JsonProperty("merge")

--- a/src/main/java/org/cyclonedx/util/deserializer/ExternalReferencesDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/ExternalReferencesDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.Property;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.List;
 public class ExternalReferencesDeserializer extends JsonDeserializer<List<ExternalReference>> {
 
     private final HashesDeserializer hashesDeserializer = new HashesDeserializer();
+    private final PropertiesDeserializer propertiesDeserializer = new PropertiesDeserializer();
 
     @Override
     public List<ExternalReference> deserialize(JsonParser parser, DeserializationContext context) throws IOException {
@@ -68,6 +70,12 @@ public class ExternalReferencesDeserializer extends JsonDeserializer<List<Extern
             JsonParser hashesParser = node.get("hashes").traverse(p.getCodec());
             hashesParser.nextToken();
             reference.setHashes(hashesDeserializer.deserialize(hashesParser, ctxt));
+        }
+        if (node.has("properties")) {
+            JsonParser propertiesParser = node.get("properties").traverse(p.getCodec());
+            propertiesParser.nextToken();
+            List<Property> properties = propertiesDeserializer.deserialize(propertiesParser, ctxt);
+            reference.setProperties(properties);
         }
         return reference;
     }

--- a/src/main/java/org/cyclonedx/util/deserializer/MetadataDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/MetadataDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.model.DistributionConstraints;
 import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.Lifecycles;
 import org.cyclonedx.model.Metadata;
@@ -90,6 +91,11 @@ public class MetadataDeserializer
       ToolsJsonParser toolsParser = new ToolsJsonParser(node, jsonParser, ctxt);
       metadata.setTools(toolsParser.getTools());
       metadata.setToolChoice(toolsParser.getToolInformation());
+    }
+
+    if (node.has("distributionConstraints")) {
+      DistributionConstraints dc = mapper.convertValue(node.get("distributionConstraints"), DistributionConstraints.class);
+      metadata.setDistributionConstraints(dc);
     }
 
     return metadata;

--- a/src/main/java/org/cyclonedx/util/deserializer/OrganizationalChoiceDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/OrganizationalChoiceDeserializer.java
@@ -30,9 +30,11 @@ import org.cyclonedx.model.OrganizationalContact;
 import org.cyclonedx.model.OrganizationalEntity;
 
 /**
- * Deserializer for OrganizationalChoice that handles both:
- * 1. Object format: {"individual": {...}} or {"organization": {...}}
+ * Deserializer for OrganizationalChoice that handles:
+ * 1. Wrapped format: {"individual": {...}} or {"organization": {...}} (Licensing)
  * 2. String format: "bom-ref" (reference to an organization defined elsewhere)
+ * 3. XML ref format: {"ref": "bom-ref"} (XML asserter with ref element)
+ * 4. Unwrapped format: direct entity/contact object fields (patent asserter/assignee JSON)
  */
 public class OrganizationalChoiceDeserializer extends JsonDeserializer<OrganizationalChoice>
 {
@@ -50,16 +52,42 @@ public class OrganizationalChoiceDeserializer extends JsonDeserializer<Organizat
       return choice;
     }
 
-    // Object format - deserialize normally
+    // Object format
     JsonNode node = p.getCodec().readTree(p);
     OrganizationalChoice choice = new OrganizationalChoice();
 
+    // Wrapped format (Licensing): {"individual": {...}} or {"organization": {...}}
     if (node.has("individual")) {
       OrganizationalContact individual = p.getCodec().treeToValue(node.get("individual"), OrganizationalContact.class);
       choice.setIndividual(individual);
     } else if (node.has("organization")) {
       OrganizationalEntity organization = p.getCodec().treeToValue(node.get("organization"), OrganizationalEntity.class);
       choice.setOrganization(organization);
+    }
+    // XML ref format: <ref>bom-ref</ref> → {"ref": "bom-ref"}
+    else if (node.has("ref")) {
+      String bomRef = node.get("ref").asText();
+      OrganizationalEntity org = new OrganizationalEntity();
+      org.setBomRef(bomRef);
+      choice.setOrganization(org);
+    }
+    // XML contact format: <contact>...</contact> (asserter XSD uses "contact" not "individual")
+    else if (node.has("contact") && !node.has("name")) {
+      OrganizationalContact contact = p.getCodec().treeToValue(node.get("contact"), OrganizationalContact.class);
+      choice.setIndividual(contact);
+    }
+    // Unwrapped format (patent JSON): direct entity or contact fields
+    else if (node.size() > 0) {
+      // Distinguish entity from contact by field presence
+      if (node.has("email") || node.has("phone")) {
+        // OrganizationalContact fields
+        OrganizationalContact contact = p.getCodec().treeToValue(node, OrganizationalContact.class);
+        choice.setIndividual(contact);
+      } else {
+        // OrganizationalEntity fields (name, url, contact, address, bom-ref)
+        OrganizationalEntity entity = p.getCodec().treeToValue(node, OrganizationalEntity.class);
+        choice.setOrganization(entity);
+      }
     }
 
     return choice;

--- a/src/main/java/org/cyclonedx/util/deserializer/PatentAssertionDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/PatentAssertionDeserializer.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util.deserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.cyclonedx.model.OrganizationalChoice;
+import org.cyclonedx.model.PatentAssertion;
+import org.cyclonedx.model.PatentAssertion.AssertionType;
+
+/**
+ * Custom deserializer for PatentAssertion that handles the bom-ref attribute/element conflict
+ * in XML. In XML, "bom-ref" appears as both an attribute on &lt;patentAssertion&gt; and as
+ * child elements inside &lt;patentRefs&gt;. Jackson XML's default property resolution confuses
+ * these, so this deserializer handles them manually.
+ */
+public class PatentAssertionDeserializer extends JsonDeserializer<PatentAssertion> {
+
+    @Override
+    public PatentAssertion deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.readValueAsTree();
+        PatentAssertion pa = new PatentAssertion();
+
+        // bom-ref (attribute in XML, property in JSON)
+        if (node.has("bom-ref")) {
+            JsonNode bomRefNode = node.get("bom-ref");
+            if (bomRefNode.isTextual()) {
+                pa.setBomRef(bomRefNode.asText());
+            }
+        }
+
+        // assertionType
+        if (node.has("assertionType")) {
+            pa.setAssertionType(AssertionType.fromValue(node.get("assertionType").asText()));
+        }
+
+        // patentRefs - in JSON it's an array of strings, in XML it's an object with bom-ref children
+        if (node.has("patentRefs")) {
+            JsonNode patentRefsNode = node.get("patentRefs");
+            List<String> refs = new ArrayList<>();
+            if (patentRefsNode.isArray()) {
+                // JSON format: ["patent-1", "patent-2"]
+                for (JsonNode ref : patentRefsNode) {
+                    refs.add(ref.asText());
+                }
+            } else if (patentRefsNode.isObject()) {
+                // XML format: {"bom-ref": "patent-1"} or {"bom-ref": ["patent-1", "patent-2"]}
+                JsonNode bomRefChildren = patentRefsNode.get("bom-ref");
+                if (bomRefChildren != null) {
+                    if (bomRefChildren.isArray()) {
+                        for (JsonNode ref : bomRefChildren) {
+                            refs.add(ref.asText());
+                        }
+                    } else {
+                        refs.add(bomRefChildren.asText());
+                    }
+                }
+            }
+            if (!refs.isEmpty()) {
+                pa.setPatentRefs(refs);
+            }
+        }
+
+        // asserter (OrganizationalChoice)
+        if (node.has("asserter")) {
+            JsonNode asserterNode = node.get("asserter");
+            OrganizationalChoiceDeserializer choiceDeser = new OrganizationalChoiceDeserializer();
+            JsonParser asserterParser = asserterNode.traverse(p.getCodec());
+            asserterParser.nextToken();
+            OrganizationalChoice asserter = choiceDeser.deserialize(asserterParser, ctxt);
+            pa.setAsserter(asserter);
+        }
+
+        // notes
+        if (node.has("notes")) {
+            pa.setNotes(node.get("notes").asText());
+        }
+
+        return pa;
+    }
+}

--- a/src/main/java/org/cyclonedx/util/deserializer/PatentItemDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/PatentItemDeserializer.java
@@ -1,0 +1,33 @@
+package org.cyclonedx.util.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cyclonedx.model.Patent;
+import org.cyclonedx.model.PatentFamily;
+import org.cyclonedx.model.PatentItem;
+
+import java.io.IOException;
+
+/**
+ * Deserializes a JSON object that could be either a Patent or a PatentFamily.
+ * Discrimination heuristic: if the object contains "familyId" or "members", it's a PatentFamily.
+ */
+public class PatentItemDeserializer extends JsonDeserializer<PatentItem> {
+
+    @Override
+    public PatentItem deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.readValueAsTree();
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+
+        if (node.has("familyId") || node.has("members")) {
+            PatentFamily pf = mapper.treeToValue(node, PatentFamily.class);
+            return PatentItem.ofPatentFamily(pf);
+        } else {
+            Patent patent = mapper.treeToValue(node, Patent.class);
+            return PatentItem.ofPatent(patent);
+        }
+    }
+}

--- a/src/main/java/org/cyclonedx/util/deserializer/PatentsDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/PatentsDeserializer.java
@@ -1,0 +1,96 @@
+package org.cyclonedx.util.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
+import org.cyclonedx.model.Patent;
+import org.cyclonedx.model.PatentFamily;
+import org.cyclonedx.model.PatentItem;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deserializes the polymorphic patents array which can contain
+ * both Patent and PatentFamily objects.
+ *
+ * For JSON: reads the array and discriminates by presence of "familyId" or "members".
+ * For XML: reads the tree and groups by "patent" and "patentFamily" element names.
+ */
+public class PatentsDeserializer extends JsonDeserializer<List<PatentItem>> {
+
+    @Override
+    public List<PatentItem> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p instanceof FromXmlParser) {
+            return deserializeXml(p, ctxt);
+        }
+        return deserializeJson(p, ctxt);
+    }
+
+    private List<PatentItem> deserializeJson(JsonParser p, DeserializationContext ctxt) throws IOException {
+        List<PatentItem> items = new ArrayList<>();
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+
+        if (p.currentToken() == JsonToken.START_ARRAY) {
+            while (p.nextToken() != JsonToken.END_ARRAY) {
+                JsonNode node = mapper.readTree(p);
+                if (node.has("familyId") || node.has("members")) {
+                    PatentFamily pf = mapper.treeToValue(node, PatentFamily.class);
+                    items.add(PatentItem.ofPatentFamily(pf));
+                } else {
+                    Patent patent = mapper.treeToValue(node, Patent.class);
+                    items.add(PatentItem.ofPatent(patent));
+                }
+            }
+        }
+
+        return items.isEmpty() ? null : items;
+    }
+
+    private List<PatentItem> deserializeXml(JsonParser p, DeserializationContext ctxt) throws IOException {
+        List<PatentItem> items = new ArrayList<>();
+
+        // For XML, we're inside the <patents> wrapper element.
+        // Children can be <patent> or <patentFamily> elements.
+        // Jackson XML presents them as field names within the current object.
+        if (p.currentToken() == JsonToken.START_OBJECT) {
+            while (p.nextToken() != JsonToken.END_OBJECT) {
+                if (p.currentToken() == JsonToken.FIELD_NAME) {
+                    String fieldName = p.currentName();
+                    p.nextToken();
+
+                    if ("patent".equals(fieldName)) {
+                        if (p.currentToken() == JsonToken.START_ARRAY) {
+                            while (p.nextToken() != JsonToken.END_ARRAY) {
+                                Patent patent = ctxt.readValue(p, Patent.class);
+                                items.add(PatentItem.ofPatent(patent));
+                            }
+                        } else {
+                            Patent patent = ctxt.readValue(p, Patent.class);
+                            items.add(PatentItem.ofPatent(patent));
+                        }
+                    } else if ("patentFamily".equals(fieldName)) {
+                        if (p.currentToken() == JsonToken.START_ARRAY) {
+                            while (p.nextToken() != JsonToken.END_ARRAY) {
+                                PatentFamily pf = ctxt.readValue(p, PatentFamily.class);
+                                items.add(PatentItem.ofPatentFamily(pf));
+                            }
+                        } else {
+                            PatentFamily pf = ctxt.readValue(p, PatentFamily.class);
+                            items.add(PatentItem.ofPatentFamily(pf));
+                        }
+                    } else {
+                        p.skipChildren();
+                    }
+                }
+            }
+        }
+
+        return items.isEmpty() ? null : items;
+    }
+}

--- a/src/main/java/org/cyclonedx/util/serializer/CustomSerializerModifier.java
+++ b/src/main/java/org/cyclonedx/util/serializer/CustomSerializerModifier.java
@@ -7,13 +7,18 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.VersionFilter;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class CustomSerializerModifier
     extends BeanSerializerModifier
 {
+  private static final Logger LOGGER = Logger.getLogger(CustomSerializerModifier.class.getName());
+
   private final Version version;
 
   private final boolean isXml;
@@ -29,12 +34,28 @@ public class CustomSerializerModifier
       BeanDescription beanDesc,
       List<BeanPropertyWriter> beanProperties)
   {
-    //Properties were introduced in 1.3 for XML and 1.5 for JSON
-    //Meaning that we should only serialize properties if the version is 1.3 or higher for XML
-    //and 1.5 or higher for JSON
-    //This is to ensure backwards compatibility with older versions of the schema
+    // Automatically remove fields annotated with @VersionFilter whose version
+    // is above the target generation version. This applies to ALL model classes,
+    // ensuring version-specific fields are never serialized for older BOM versions.
+    Iterator<BeanPropertyWriter> iterator = beanProperties.iterator();
+    while (iterator.hasNext()) {
+      BeanPropertyWriter writer = iterator.next();
+      VersionFilter filter = writer.getAnnotation(VersionFilter.class);
+      if (filter != null && filter.value().getVersion() > version.getVersion()) {
+        if (LOGGER.isLoggable(Level.FINE)) {
+          LOGGER.fine(String.format(
+              "Removing field '%s' on %s: introduced in version %s but generating for version %s",
+              writer.getName(), beanDesc.getBeanClass().getSimpleName(),
+              filter.value().getVersionString(), version.getVersionString()));
+        }
+        iterator.remove();
+      }
+    }
+
+    // Special case: Bom.properties has different version thresholds for XML (1.3) and JSON (1.5).
+    // This cannot be expressed with a single @VersionFilter annotation.
     if (Bom.class.isAssignableFrom(beanDesc.getBeanClass())) {
-      Iterator<BeanPropertyWriter> iterator = beanProperties.iterator();
+      iterator = beanProperties.iterator();
       while (iterator.hasNext()) {
         BeanPropertyWriter writer = iterator.next();
         if (isValidAttribute(writer)) {

--- a/src/main/java/org/cyclonedx/util/serializer/EnvironmentVarsSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/EnvironmentVarsSerializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cyclonedx.Version;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.formulation.common.EnvironmentVars;
 
@@ -15,13 +16,16 @@ public class EnvironmentVarsSerializer
 {
   private final boolean isXml;
 
-  public EnvironmentVarsSerializer(boolean isXml) {
-    this(null, isXml);
+  private final Version version;
+
+  public EnvironmentVarsSerializer(boolean isXml, Version version) {
+    this(null, isXml, version);
   }
 
-  public EnvironmentVarsSerializer(Class<EnvironmentVars> t, boolean isXml) {
+  public EnvironmentVarsSerializer(Class<EnvironmentVars> t, boolean isXml, Version version) {
     super(t);
     this.isXml = isXml;
+    this.version = version;
   }
 
   @Override

--- a/src/main/java/org/cyclonedx/util/serializer/ExternalReferenceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/ExternalReferenceSerializer.java
@@ -19,6 +19,7 @@
 package org.cyclonedx.util.serializer;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.function.BiPredicate;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -30,7 +31,6 @@ import org.cyclonedx.Version;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.ExternalReference.Type;
 import org.cyclonedx.model.Hash;
-import org.cyclonedx.model.VersionFilter;
 import org.cyclonedx.util.BomUtils;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.serializeHashJson;
@@ -60,7 +60,7 @@ public class ExternalReferenceSerializer
       return;
     }
 
-    if(!shouldSerializeField(extRef.getType())) {
+    if (!SerializerUtils.shouldSerializeEnumValue(extRef.getType(), version)) {
       return;
     }
 
@@ -84,10 +84,12 @@ public class ExternalReferenceSerializer
     if (extRef.getComment() != null) {
       toXmlGenerator.writeStringField("comment", extRef.getComment());
     }
-    if (CollectionUtils.isNotEmpty(extRef.getHashes())) {
+
+    List<Hash> hashes = SerializerUtils.filterHashesByVersion(extRef.getHashes(), version);
+    if (CollectionUtils.isNotEmpty(hashes)) {
       toXmlGenerator.writeFieldName("hashes");
       toXmlGenerator.writeStartObject();
-      for (Hash hash : extRef.getHashes()) {
+      for (Hash hash : hashes) {
         toXmlGenerator.writeFieldName("hash");
         SerializerUtils.serializeHashXml(toXmlGenerator, hash);
       }
@@ -103,28 +105,17 @@ public class ExternalReferenceSerializer
     if (extRef.getComment() != null) {
       gen.writeStringField("comment", extRef.getComment());
     }
-    if (CollectionUtils.isNotEmpty(extRef.getHashes())) {
+
+    List<Hash> hashes = SerializerUtils.filterHashesByVersion(extRef.getHashes(), version);
+    if (CollectionUtils.isNotEmpty(hashes)) {
       gen.writeFieldName("hashes");
       gen.writeStartArray();
-      for (Hash hash : extRef.getHashes()) {
+      for (Hash hash : hashes) {
         serializeHashJson(gen, hash);
       }
       gen.writeEndArray();
     }
     gen.writeEndObject();
-  }
-
-  private boolean shouldSerializeField(Object obj) {
-    try {
-      if (obj instanceof Type) {
-        Type type = (Type) obj;
-        VersionFilter filter = type.getClass().getField(type.name()).getAnnotation(VersionFilter.class);
-        return filter == null || filter.value().getVersion() <= version.getVersion();
-      }
-      return true;
-    }catch (NoSuchFieldException e) {
-      return false;
-    }
   }
 
   @Override

--- a/src/main/java/org/cyclonedx/util/serializer/HashSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/HashSerializer.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.Hash.Algorithm;
-import org.cyclonedx.model.VersionFilter;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.serializeHashJson;
 
@@ -49,7 +48,7 @@ public class HashSerializer
   public void serialize(
       final Hash hash, final JsonGenerator gen, final SerializerProvider provider) throws IOException
   {
-    if (!shouldSerializeField(hash.getAlgorithm())) {
+    if (!shouldSerializeHash(hash)) {
       return;
     }
 
@@ -66,14 +65,16 @@ public class HashSerializer
     return Hash.class;
   }
 
-  private boolean shouldSerializeField(String value) {
-    try {
-      Algorithm algorithm = Algorithm.fromSpec(value);
-      VersionFilter filter = algorithm.getClass().getField(algorithm.name()).getAnnotation(VersionFilter.class);
-      return filter == null || filter.value().getVersion() <= version.getVersion();
+  private boolean shouldSerializeHash(Hash hash) {
+    if (hash.getAlgorithm() == null) {
+      return true;
     }
-    catch (NoSuchFieldException e) {
-      return false;
+    try {
+      Algorithm algorithm = Algorithm.fromSpec(hash.getAlgorithm());
+      return SerializerUtils.shouldSerializeEnumValue(algorithm, version);
+    } catch (IllegalArgumentException e) {
+      // Unknown algorithm - include it
+      return true;
     }
   }
 }

--- a/src/main/java/org/cyclonedx/util/serializer/IkeV2TransformSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/IkeV2TransformSerializer.java
@@ -21,13 +21,26 @@ package org.cyclonedx.util.serializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import org.cyclonedx.Version;
 import org.cyclonedx.model.component.crypto.AbstractIkeV2Transform;
 import org.cyclonedx.model.component.crypto.IkeV2Enc;
 import org.cyclonedx.model.component.crypto.IkeV2Ke;
 
 import java.io.IOException;
 
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
+
 public class IkeV2TransformSerializer extends JsonSerializer<AbstractIkeV2Transform> {
+
+  private final Version version;
+
+  public IkeV2TransformSerializer() {
+    this(null);
+  }
+
+  public IkeV2TransformSerializer(Version version) {
+    this.version = version;
+  }
 
   @Override
   public void serialize(AbstractIkeV2Transform value, JsonGenerator gen, SerializerProvider provider)
@@ -41,21 +54,21 @@ public class IkeV2TransformSerializer extends JsonSerializer<AbstractIkeV2Transf
     gen.writeStartObject();
     if (value instanceof IkeV2Ke) {
       IkeV2Ke ke = (IkeV2Ke) value;
-      if (ke.getGroup() != null) {
+      if (ke.getGroup() != null && shouldSerializeField(ke, version, "group")) {
         gen.writeNumberField("group", ke.getGroup());
       }
     } else {
-      if (value.getName() != null) {
+      if (value.getName() != null && shouldSerializeField(value, version, "name")) {
         gen.writeStringField("name", value.getName());
       }
       if (value instanceof IkeV2Enc) {
         IkeV2Enc enc = (IkeV2Enc) value;
-        if (enc.getKeyLength() != null) {
+        if (enc.getKeyLength() != null && shouldSerializeField(enc, version, "keyLength")) {
           gen.writeNumberField("keyLength", enc.getKeyLength());
         }
       }
     }
-    if (value.getAlgorithm() != null) {
+    if (value.getAlgorithm() != null && shouldSerializeField(value, version, "algorithm")) {
       gen.writeStringField("algorithm", value.getAlgorithm());
     }
     gen.writeEndObject();

--- a/src/main/java/org/cyclonedx/util/serializer/InputTypeSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/InputTypeSerializer.java
@@ -7,20 +7,26 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.apache.commons.collections4.CollectionUtils;
+import org.cyclonedx.Version;
 import org.cyclonedx.model.formulation.common.InputType;
+
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
 public class InputTypeSerializer
     extends StdSerializer<InputType>
 {
   private final boolean isXml;
 
-  public InputTypeSerializer(boolean isXml) {
-    this(null, isXml);
+  private final Version version;
+
+  public InputTypeSerializer(boolean isXml, Version version) {
+    this(null, isXml, version);
   }
 
-  public InputTypeSerializer(Class<InputType> t, boolean isXml) {
+  public InputTypeSerializer(Class<InputType> t, boolean isXml, Version version) {
     super(t);
     this.isXml = isXml;
+    this.version = version;
   }
 
   @Override
@@ -39,25 +45,31 @@ public class InputTypeSerializer
   {
     jsonGenerator.writeStartObject();
 
-    if (input.getResource() != null) {
+    if (input.getResource() != null && shouldSerializeField(input, version, "resource")) {
       jsonGenerator.writeFieldName("resource");
       jsonGenerator.writeObject(input.getResource());
     }
-    else if (CollectionUtils.isNotEmpty(input.getParameters())) {
+    else if (CollectionUtils.isNotEmpty(input.getParameters()) && shouldSerializeField(input, version, "parameters")) {
       jsonGenerator.writeFieldName("parameters");
       jsonGenerator.writeObject(input.getParameters());
     }
-    else if (input.getEnvironmentVars() != null) {
-      new EnvironmentVarsSerializer(isXml).serialize(input.getEnvironmentVars(), jsonGenerator, serializerProvider);
+    else if (input.getEnvironmentVars() != null && shouldSerializeField(input, version, "environmentVars")) {
+      new EnvironmentVarsSerializer(isXml, version).serialize(input.getEnvironmentVars(), jsonGenerator, serializerProvider);
     }
-    else if (input.getData() != null) {
+    else if (input.getData() != null && shouldSerializeField(input, version, "data")) {
       jsonGenerator.writeFieldName("data");
       jsonGenerator.writeObject(input.getData());
     }
 
-    SerializerUtils.writeField(jsonGenerator, "source", input.getSource());
-    SerializerUtils.writeField(jsonGenerator, "target", input.getTarget());
-    SerializerUtils.writeField(jsonGenerator, "properties", input.getProperties());
+    if (input.getSource() != null && shouldSerializeField(input, version, "source")) {
+      SerializerUtils.writeField(jsonGenerator, "source", input.getSource());
+    }
+    if (input.getTarget() != null && shouldSerializeField(input, version, "target")) {
+      SerializerUtils.writeField(jsonGenerator, "target", input.getTarget());
+    }
+    if (input.getProperties() != null && shouldSerializeField(input, version, "properties")) {
+      SerializerUtils.writeField(jsonGenerator, "properties", input.getProperties());
+    }
 
     jsonGenerator.writeEndObject();
   }

--- a/src/main/java/org/cyclonedx/util/serializer/LicenseChoiceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/LicenseChoiceSerializer.java
@@ -87,7 +87,7 @@ public class LicenseChoiceSerializer
         serializeLicenseToXml(toXmlGenerator, item.getLicense(), provider);
       } else if (item.getExpression() != null) {
         serializeExpressionToXml(toXmlGenerator, item.getExpression());
-      } else if (item.getExpressionDetailed() != null) {
+      } else if (item.getExpressionDetailed() != null && shouldSerializeField(item, version, "expressionDetailed")) {
         serializeExpressionDetailedToXml(toXmlGenerator, item.getExpressionDetailed(), provider);
       }
     }
@@ -165,15 +165,19 @@ public class LicenseChoiceSerializer
   {
     gen.writeStartArray();
     for (LicenseItem item : licenseChoice.getItems()) {
-      gen.writeStartObject();
       if (item.getLicense() != null) {
+        gen.writeStartObject();
         provider.defaultSerializeField("license", item.getLicense(), gen);
+        gen.writeEndObject();
       } else if (item.getExpression() != null) {
+        gen.writeStartObject();
         serializeExpressionToJson(item.getExpression(), gen);
-      } else if (item.getExpressionDetailed() != null) {
+        gen.writeEndObject();
+      } else if (item.getExpressionDetailed() != null && shouldSerializeField(item, version, "expressionDetailed")) {
+        gen.writeStartObject();
         serializeExpressionDetailedToJson(item.getExpressionDetailed(), gen, provider);
+        gen.writeEndObject();
       }
-      gen.writeEndObject();
     }
     gen.writeEndArray();
   }
@@ -196,10 +200,6 @@ public class LicenseChoiceSerializer
       final SerializerProvider provider)
       throws IOException
   {
-    if (version.getVersion() < 1.7) {
-      return; // ExpressionDetailed is only for 1.7+
-    }
-
     toXmlGenerator.writeFieldName("expression-detailed");
     toXmlGenerator.writeStartObject();
 
@@ -250,10 +250,6 @@ public class LicenseChoiceSerializer
   private void serializeExpressionDetailedToJson(
       final ExpressionDetailed expressionDetailed, final JsonGenerator gen, final SerializerProvider provider)
       throws IOException {
-    if (version.getVersion() < 1.7) {
-      return; // ExpressionDetailed is only for 1.7+
-    }
-
     // Flatten the expressionDetailed fields into the license item object
     if (StringUtils.isNotBlank(expressionDetailed.getBomRef())) {
       gen.writeStringField("bom-ref", expressionDetailed.getBomRef());

--- a/src/main/java/org/cyclonedx/util/serializer/LifecycleSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/LifecycleSerializer.java
@@ -4,24 +4,30 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cyclonedx.Version;
 import org.cyclonedx.model.LifecycleChoice;
 import org.cyclonedx.model.Lifecycles;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
+
 public class LifecycleSerializer
     extends StdSerializer<Lifecycles>
 {
   private final boolean isXml;
 
-  public LifecycleSerializer(boolean isXml) {
-    this(null, isXml);
+  private final Version version;
+
+  public LifecycleSerializer(boolean isXml, Version version) {
+    this(null, isXml, version);
   }
 
-  public LifecycleSerializer(Class<Lifecycles> t, boolean isXml) {
+  public LifecycleSerializer(Class<Lifecycles> t, boolean isXml, Version version) {
     super(t);
     this.isXml = isXml;
+    this.version = version;
   }
 
   @Override
@@ -47,11 +53,15 @@ public class LifecycleSerializer
     List<LifecycleChoice> lifecycleChoices = lifecycles.getLifecycleChoice();
     for (LifecycleChoice choice : lifecycleChoices) {
       jsonGenerator.writeStartObject();
-      if (choice.getPhase() != null) {
+      if (choice.getPhase() != null && shouldSerializeField(choice, version, "phase")) {
         jsonGenerator.writeStringField("phase", choice.getPhase().getPhaseName());
       } else {
-        jsonGenerator.writeStringField("name", choice.getName());
-        jsonGenerator.writeStringField("description", choice.getDescription());
+        if (choice.getName() != null && shouldSerializeField(choice, version, "name")) {
+          jsonGenerator.writeStringField("name", choice.getName());
+        }
+        if (choice.getDescription() != null && shouldSerializeField(choice, version, "description")) {
+          jsonGenerator.writeStringField("description", choice.getDescription());
+        }
       }
       jsonGenerator.writeEndObject();
     }

--- a/src/main/java/org/cyclonedx/util/serializer/MetadataSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/MetadataSerializer.java
@@ -60,7 +60,7 @@ public class MetadataSerializer
 
     if (metadata.getLifecycles() != null && shouldSerializeField(metadata, version, "lifecycles")) {
       jsonGenerator.writeFieldName("lifecycles");
-      new LifecycleSerializer(isXml).serialize(metadata.getLifecycles(), jsonGenerator, serializerProvider);
+      new LifecycleSerializer(isXml, version).serialize(metadata.getLifecycles(), jsonGenerator, serializerProvider);
     }
 
     //Tools

--- a/src/main/java/org/cyclonedx/util/serializer/OrganizationalChoiceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/OrganizationalChoiceSerializer.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util.serializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cyclonedx.Version;
+import org.cyclonedx.model.OrganizationalChoice;
+import org.cyclonedx.model.OrganizationalEntity;
+
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
+
+/**
+ * Serializer for OrganizationalChoice in patent contexts where the JSON schema uses
+ * unwrapped format (direct entity/contact/string ref) rather than the Licensing wrapped
+ * format ({"organization": {...}} / {"individual": {...}}).
+ *
+ * <p>JSON output:
+ * <ul>
+ *   <li>Org with only bomRef: string "org-acme-inc"</li>
+ *   <li>Org with other fields: direct entity object {"name": "...", "url": [...]}</li>
+ *   <li>Individual: direct contact object {"name": "...", "email": "..."}</li>
+ * </ul>
+ *
+ * <p>XML output (inside the parent element like &lt;asserter&gt; or &lt;patentAssignee&gt;):
+ * <ul>
+ *   <li>Org with only bomRef: &lt;ref&gt;bomRef&lt;/ref&gt;</li>
+ *   <li>Org with other fields: &lt;organization&gt;...&lt;/organization&gt;</li>
+ *   <li>Individual: &lt;individual&gt;...&lt;/individual&gt;</li>
+ * </ul>
+ */
+public class OrganizationalChoiceSerializer extends JsonSerializer<OrganizationalChoice> {
+
+    private final Version version;
+
+    public OrganizationalChoiceSerializer() {
+        this(null);
+    }
+
+    public OrganizationalChoiceSerializer(Version version) {
+        this.version = version;
+    }
+
+    @Override
+    public void serialize(OrganizationalChoice value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (gen instanceof ToXmlGenerator) {
+            serializeXml(value, (ToXmlGenerator) gen, provider);
+        } else {
+            serializeJson(value, gen, provider);
+        }
+    }
+
+    private void serializeJson(OrganizationalChoice value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (value.getOrganization() != null && shouldSerializeField(value, version, "organization")) {
+            OrganizationalEntity org = value.getOrganization();
+            if (isRefOnly(org)) {
+                gen.writeString(org.getBomRef());
+            } else {
+                provider.defaultSerializeValue(org, gen);
+            }
+        } else if (value.getIndividual() != null && shouldSerializeField(value, version, "individual")) {
+            provider.defaultSerializeValue(value.getIndividual(), gen);
+        } else {
+            gen.writeNull();
+        }
+    }
+
+    private void serializeXml(OrganizationalChoice value, ToXmlGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        // In XML, the parent element (e.g. <asserter> or <patentAssignee>) wraps this serializer's output.
+        // We write an object with a single child element: <ref>, <organization>, or <individual>.
+        gen.writeStartObject();
+        if (value.getOrganization() != null && shouldSerializeField(value, version, "organization")) {
+            OrganizationalEntity org = value.getOrganization();
+            if (isRefOnly(org)) {
+                gen.writeStringField("ref", org.getBomRef());
+            } else {
+                gen.writeFieldName("organization");
+                provider.defaultSerializeValue(org, gen);
+            }
+        } else if (value.getIndividual() != null && shouldSerializeField(value, version, "individual")) {
+            gen.writeFieldName("individual");
+            provider.defaultSerializeValue(value.getIndividual(), gen);
+        }
+        gen.writeEndObject();
+    }
+
+    private boolean isRefOnly(OrganizationalEntity org) {
+        return org.getBomRef() != null
+            && org.getName() == null
+            && (org.getUrls() == null || org.getUrls().isEmpty())
+            && (org.getContacts() == null || org.getContacts().isEmpty())
+            && org.getAddress() == null;
+    }
+}

--- a/src/main/java/org/cyclonedx/util/serializer/OutputTypeSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/OutputTypeSerializer.java
@@ -7,20 +7,26 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.apache.commons.collections4.CollectionUtils;
+import org.cyclonedx.Version;
 import org.cyclonedx.model.formulation.common.OutputType;
+
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
 public class OutputTypeSerializer
     extends StdSerializer<OutputType>
 {
   private final boolean isXml;
 
-  public OutputTypeSerializer(boolean isXml) {
-    this(null, isXml);
+  private final Version version;
+
+  public OutputTypeSerializer(boolean isXml, Version version) {
+    this(null, isXml, version);
   }
 
-  public OutputTypeSerializer(Class<OutputType> t, boolean isXml) {
+  public OutputTypeSerializer(Class<OutputType> t, boolean isXml, Version version) {
     super(t);
     this.isXml = isXml;
+    this.version = version;
   }
 
   @Override
@@ -39,22 +45,30 @@ public class OutputTypeSerializer
   {
     jsonGenerator.writeStartObject();
 
-    if (output.getResource() != null) {
+    if (output.getResource() != null && shouldSerializeField(output, version, "resource")) {
       jsonGenerator.writeFieldName("resource");
-      jsonGenerator.writeObject( output.getResource());
+      jsonGenerator.writeObject(output.getResource());
     }
-    else if (output.getEnvironmentVars() != null) {
-      new EnvironmentVarsSerializer(isXml).serialize(output.getEnvironmentVars(), jsonGenerator, serializerProvider);
+    else if (output.getEnvironmentVars() != null && shouldSerializeField(output, version, "environmentVars")) {
+      new EnvironmentVarsSerializer(isXml, version).serialize(output.getEnvironmentVars(), jsonGenerator, serializerProvider);
     }
-    else if (output.getData() != null) {
+    else if (output.getData() != null && shouldSerializeField(output, version, "data")) {
       jsonGenerator.writeFieldName("data");
-      jsonGenerator.writeObject( output.getData());
+      jsonGenerator.writeObject(output.getData());
     }
 
-    SerializerUtils.writeField(jsonGenerator, "type", output.getType());
-    SerializerUtils.writeField(jsonGenerator, "source", output.getSource());
-    SerializerUtils.writeField(jsonGenerator, "target", output.getTarget());
-    SerializerUtils.writeField(jsonGenerator, "properties", output.getProperties());
+    if (output.getType() != null && shouldSerializeField(output, version, "type")) {
+      SerializerUtils.writeField(jsonGenerator, "type", output.getType());
+    }
+    if (output.getSource() != null && shouldSerializeField(output, version, "source")) {
+      SerializerUtils.writeField(jsonGenerator, "source", output.getSource());
+    }
+    if (output.getTarget() != null && shouldSerializeField(output, version, "target")) {
+      SerializerUtils.writeField(jsonGenerator, "target", output.getTarget());
+    }
+    if (output.getProperties() != null && shouldSerializeField(output, version, "properties")) {
+      SerializerUtils.writeField(jsonGenerator, "properties", output.getProperties());
+    }
     jsonGenerator.writeEndObject();
   }
 
@@ -63,33 +77,33 @@ public class OutputTypeSerializer
   {
     xmlGenerator.writeStartObject();
 
-    if (output.getResource() != null) {
+    if (output.getResource() != null && shouldSerializeField(output, version, "resource")) {
       xmlGenerator.writeFieldName("resource");
-      xmlGenerator.writeObject( output.getResource());
+      xmlGenerator.writeObject(output.getResource());
     }
-    else if (output.getEnvironmentVars() != null) {
-      new EnvironmentVarsSerializer(isXml).serialize(output.getEnvironmentVars(), xmlGenerator, serializerProvider);
+    else if (output.getEnvironmentVars() != null && shouldSerializeField(output, version, "environmentVars")) {
+      new EnvironmentVarsSerializer(isXml, version).serialize(output.getEnvironmentVars(), xmlGenerator, serializerProvider);
     }
-    else if (output.getData() != null) {
+    else if (output.getData() != null && shouldSerializeField(output, version, "data")) {
       xmlGenerator.writeFieldName("data");
-      xmlGenerator.writeObject( output.getData());
+      xmlGenerator.writeObject(output.getData());
     }
 
-    if (output.getType() != null) {
+    if (output.getType() != null && shouldSerializeField(output, version, "type")) {
       xmlGenerator.writeFieldName("type");
       xmlGenerator.writeObject(output.getType());
     }
-    if (output.getSource() != null) {
+    if (output.getSource() != null && shouldSerializeField(output, version, "source")) {
       xmlGenerator.writeFieldName("source");
       xmlGenerator.writeObject(output.getSource());
     }
-    if (output.getTarget() != null) {
+    if (output.getTarget() != null && shouldSerializeField(output, version, "target")) {
       xmlGenerator.writeFieldName("target");
       xmlGenerator.writeObject(output.getTarget());
     }
-    if (CollectionUtils.isNotEmpty(output.getProperties())) {
+    if (CollectionUtils.isNotEmpty(output.getProperties()) && shouldSerializeField(output, version, "properties")) {
       xmlGenerator.writeFieldName("properties");
-      xmlGenerator.writeObject( output.getProperties());
+      xmlGenerator.writeObject(output.getProperties());
     }
     xmlGenerator.writeEndObject();
   }

--- a/src/main/java/org/cyclonedx/util/serializer/PatentAssertionSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/PatentAssertionSerializer.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util.serializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cyclonedx.Version;
+import org.cyclonedx.model.PatentAssertion;
+
+import javax.xml.namespace.QName;
+
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
+
+/**
+ * Custom serializer for PatentAssertion that handles the bom-ref attribute/element name
+ * conflict in XML. In XML, "bom-ref" appears as both an attribute on &lt;patentAssertion&gt;
+ * and as child elements inside &lt;patentRefs&gt;. Jackson XML cannot distinguish these,
+ * so this serializer handles the XML output manually.
+ */
+public class PatentAssertionSerializer extends JsonSerializer<PatentAssertion> {
+
+    private final Version version;
+
+    private final OrganizationalChoiceSerializer choiceSerializer;
+
+    public PatentAssertionSerializer() {
+        this(null);
+    }
+
+    public PatentAssertionSerializer(Version version) {
+        this.version = version;
+        this.choiceSerializer = new OrganizationalChoiceSerializer(version);
+    }
+
+    @Override
+    public void serialize(PatentAssertion value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (gen instanceof ToXmlGenerator) {
+            serializeXml(value, (ToXmlGenerator) gen, provider);
+        } else {
+            serializeJson(value, gen, provider);
+        }
+    }
+
+    private void serializeJson(PatentAssertion value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        gen.writeStartObject();
+        if (value.getBomRef() != null && shouldSerializeField(value, version, "bomRef")) {
+            gen.writeStringField("bom-ref", value.getBomRef());
+        }
+        if (value.getAssertionType() != null && shouldSerializeField(value, version, "assertionType")) {
+            gen.writeStringField("assertionType", value.getAssertionType().getValue());
+        }
+        if (value.getPatentRefs() != null && !value.getPatentRefs().isEmpty() && shouldSerializeField(value, version, "patentRefs")) {
+            gen.writeArrayFieldStart("patentRefs");
+            for (String ref : value.getPatentRefs()) {
+                gen.writeString(ref);
+            }
+            gen.writeEndArray();
+        }
+        if (value.getAsserter() != null && shouldSerializeField(value, version, "asserter")) {
+            gen.writeFieldName("asserter");
+            choiceSerializer.serialize(value.getAsserter(), gen, provider);
+        }
+        if (value.getNotes() != null && shouldSerializeField(value, version, "notes")) {
+            gen.writeStringField("notes", value.getNotes());
+        }
+        gen.writeEndObject();
+    }
+
+    private void serializeXml(PatentAssertion value, ToXmlGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        gen.writeStartObject();
+
+        // Write bom-ref as XML attribute
+        if (value.getBomRef() != null && shouldSerializeField(value, version, "bomRef")) {
+            gen.setNextIsAttribute(true);
+            gen.setNextName(new QName("bom-ref"));
+            gen.writeFieldName("bom-ref");
+            gen.writeString(value.getBomRef());
+            gen.setNextIsAttribute(false);
+        }
+
+        // assertionType
+        if (value.getAssertionType() != null && shouldSerializeField(value, version, "assertionType")) {
+            gen.writeStringField("assertionType", value.getAssertionType().getValue());
+        }
+
+        // patentRefs wrapper with bom-ref child elements
+        if (value.getPatentRefs() != null && !value.getPatentRefs().isEmpty() && shouldSerializeField(value, version, "patentRefs")) {
+            gen.writeFieldName("patentRefs");
+            gen.writeStartObject();
+            for (String ref : value.getPatentRefs()) {
+                gen.writeStringField("bom-ref", ref);
+            }
+            gen.writeEndObject();
+        }
+
+        // asserter (delegates to OrganizationalChoiceSerializer)
+        if (value.getAsserter() != null && shouldSerializeField(value, version, "asserter")) {
+            gen.writeFieldName("asserter");
+            choiceSerializer.serialize(value.getAsserter(), gen, provider);
+        }
+
+        // notes
+        if (value.getNotes() != null && shouldSerializeField(value, version, "notes")) {
+            gen.writeStringField("notes", value.getNotes());
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/org/cyclonedx/util/serializer/PatentItemSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/PatentItemSerializer.java
@@ -1,0 +1,67 @@
+package org.cyclonedx.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.cyclonedx.Version;
+import org.cyclonedx.model.PatentItem;
+
+import javax.xml.namespace.QName;
+import java.io.IOException;
+
+import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
+
+/**
+ * Serializes a PatentItem by flattening — writing the inner Patent or PatentFamily
+ * object directly. For XML, sets the correct element name.
+ */
+public class PatentItemSerializer extends JsonSerializer<PatentItem> {
+
+    private final Version version;
+
+    public PatentItemSerializer() {
+        this(null);
+    }
+
+    public PatentItemSerializer(Version version) {
+        this.version = version;
+    }
+
+    @Override
+    public void serialize(PatentItem value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (gen instanceof ToXmlGenerator) {
+            serializeXml(value, (ToXmlGenerator) gen, provider);
+        } else {
+            serializeJson(value, gen, provider);
+        }
+    }
+
+    private void serializeJson(PatentItem value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (value.getPatent() != null && shouldSerializeField(value, version, "patent")) {
+            provider.defaultSerializeValue(value.getPatent(), gen);
+        } else if (value.getPatentFamily() != null && shouldSerializeField(value, version, "patentFamily")) {
+            provider.defaultSerializeValue(value.getPatentFamily(), gen);
+        } else {
+            gen.writeNull();
+        }
+    }
+
+    private void serializeXml(PatentItem value, ToXmlGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        if (value.getPatentFamily() != null && shouldSerializeField(value, version, "patentFamily")) {
+            gen.setNextName(new QName("patentFamily"));
+            provider.defaultSerializeValue(value.getPatentFamily(), gen);
+        } else if (value.getPatent() != null && shouldSerializeField(value, version, "patent")) {
+            // patent is the default element name from @JacksonXmlProperty
+            provider.defaultSerializeValue(value.getPatent(), gen);
+        } else {
+            gen.writeNull();
+        }
+    }
+}

--- a/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
+++ b/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
@@ -2,16 +2,24 @@ package org.cyclonedx.util.serializer;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.cyclonedx.Version;
+import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Hash;
+import org.cyclonedx.model.Hash.Algorithm;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.VersionFilter;
 
 public class SerializerUtils
 {
+  private static final Logger LOGGER = Logger.getLogger(SerializerUtils.class.getName());
+
   public static void serializeHashXml(final ToXmlGenerator toXmlGenerator, final Hash hash) throws IOException {
     toXmlGenerator.writeStartObject();
     toXmlGenerator.setNextIsAttribute(true);
@@ -33,14 +41,103 @@ public class SerializerUtils
   }
 
   public static boolean shouldSerializeField(Object obj, Version version, String fieldName) {
-    try {
-      Field field = obj.getClass().getDeclaredField(fieldName);
-      VersionFilter filter = field.getAnnotation(VersionFilter.class);
-      return filter == null || filter.value().getVersion() <= version.getVersion();
-    } catch (NoSuchFieldException e) {
-      // If the field does not exist, assume it should be serialized
+    if (version == null) {
       return true;
     }
+    VersionFilter filter = findVersionFilter(obj.getClass(), fieldName);
+    if (filter != null && filter.value().getVersion() > version.getVersion()) {
+      if (LOGGER.isLoggable(Level.FINE)) {
+        LOGGER.fine(String.format(
+            "Skipping field '%s' on %s: introduced in version %s but generating for version %s",
+            fieldName, obj.getClass().getSimpleName(),
+            filter.value().getVersionString(), version.getVersionString()));
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private static VersionFilter findVersionFilter(Class<?> clazz, String fieldName) {
+    // Walk up the class hierarchy to find the field (getDeclaredField only checks the immediate class)
+    Class<?> current = clazz;
+    while (current != null && current != Object.class) {
+      try {
+        Field field = current.getDeclaredField(fieldName);
+        return field.getAnnotation(VersionFilter.class);
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Checks whether an enum constant should be serialized for the target version by inspecting
+   * the {@link VersionFilter} annotation on the enum constant's field.
+   *
+   * @param enumValue the enum constant to check
+   * @param version the target BOM version being generated
+   * @return true if the enum value is valid for the target version, false otherwise
+   */
+  public static boolean shouldSerializeEnumValue(Enum<?> enumValue, Version version) {
+    try {
+      VersionFilter filter = enumValue.getClass()
+          .getField(enumValue.name())
+          .getAnnotation(VersionFilter.class);
+      if (filter != null && filter.value().getVersion() > version.getVersion()) {
+        if (LOGGER.isLoggable(Level.FINE)) {
+          LOGGER.fine(String.format(
+              "Skipping %s.%s: introduced in version %s but generating for version %s",
+              enumValue.getClass().getSimpleName(), enumValue.name(),
+              filter.value().getVersionString(), version.getVersionString()));
+        }
+        return false;
+      }
+      return true;
+    } catch (NoSuchFieldException e) {
+      return true;
+    }
+  }
+
+  /**
+   * Filters a list of ExternalReferences, removing entries whose Type has a
+   * {@link VersionFilter} above the target version.
+   */
+  public static List<ExternalReference> filterExternalReferencesByVersion(
+      List<ExternalReference> refs, Version version) {
+    if (refs == null) return null;
+    List<ExternalReference> filtered = new ArrayList<>();
+    for (ExternalReference ref : refs) {
+      if (ref.getType() == null || shouldSerializeEnumValue(ref.getType(), version)) {
+        filtered.add(ref);
+      }
+    }
+    return filtered.isEmpty() ? null : filtered;
+  }
+
+  /**
+   * Filters a list of Hashes, removing entries whose Algorithm has a
+   * {@link VersionFilter} above the target version.
+   */
+  public static List<Hash> filterHashesByVersion(List<Hash> hashes, Version version) {
+    if (hashes == null) return null;
+    List<Hash> filtered = new ArrayList<>();
+    for (Hash hash : hashes) {
+      if (hash.getAlgorithm() == null) {
+        filtered.add(hash);
+        continue;
+      }
+      try {
+        Algorithm algorithm = Algorithm.fromSpec(hash.getAlgorithm());
+        if (shouldSerializeEnumValue(algorithm, version)) {
+          filtered.add(hash);
+        }
+      } catch (IllegalArgumentException e) {
+        // Unknown algorithm - include it
+        filtered.add(hash);
+      }
+    }
+    return filtered.isEmpty() ? null : filtered;
   }
 
   public static void serializeProperty(String propertyName,  Property prop, ToXmlGenerator xmlGenerator) throws IOException {

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -778,6 +778,180 @@ public class BomJsonGeneratorTest {
         assertTrue(parser.isValid(loadedFile, version));
     }
 
+    // ==================== CycloneDX 1.7 Citation Tests ====================
+
+    @Test
+    public void schema17_testCitations() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-citations-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCitations_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-citations-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    // ==================== CycloneDX 1.7 Patent Tests ====================
+
+    @Test
+    public void schema17_testPatent() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-patent-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testPatent_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-patent-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    // ==================== CycloneDX 1.7 External Component Tests ====================
+
+    @Test
+    public void schema17_testComponentExternalVersionRange() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-with-versionRange.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalVersionRange_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-component-external-with-versionRange.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithVersion() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-with-version.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithVersion_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-component-external-with-version.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithoutVersion() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-without-version.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithoutVersion_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-component-external-without-version.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testExternalReferenceProperties() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-external-reference-properties-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testExternalReferenceProperties_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-external-reference-properties-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testMetadataDistribution() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-metadata-distribution-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testMetadataDistribution_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-metadata-distribution-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
     private void assertExternalReferenceInfo(Bom bom) {
         assertEquals(3, bom.getExternalReferences().size());
         assertEquals(3, bom.getComponents().get(0).getExternalReferences().size());

--- a/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
@@ -967,6 +967,180 @@ public class BomXmlGeneratorTest {
         assertTrue(parser.isValid(loadedFile, version));
     }
 
+    // ==================== CycloneDX 1.7 Citation Tests ====================
+
+    @Test
+    public void schema17_testCitations() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-citations-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCitations_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-citations-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    // ==================== CycloneDX 1.7 Patent Tests ====================
+
+    @Test
+    public void schema17_testPatent() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-patent-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testPatent_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-patent-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    // ==================== CycloneDX 1.7 External Component Tests ====================
+
+    @Test
+    public void schema17_testComponentExternalVersionRange() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-with-versionRange.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalVersionRange_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-component-external-with-versionRange.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithVersion() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-with-version.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithVersion_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-component-external-with-version.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithoutVersion() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-component-external-without-version.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testComponentExternalWithoutVersion_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-component-external-without-version.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testExternalReferenceProperties() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-external-reference-properties-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testExternalReferenceProperties_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-external-reference-properties-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testMetadataDistribution() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-metadata-distribution-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testMetadataDistribution_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-metadata-distribution-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
     private void assertExternalReferenceInfo(Bom bom) {
         assertEquals(3, bom.getExternalReferences().size());
         assertEquals(3, bom.getComponents().get(0).getExternalReferences().size());

--- a/src/test/java/org/cyclonedx/VersionFilteringTest.java
+++ b/src/test/java/org/cyclonedx/VersionFilteringTest.java
@@ -1,0 +1,297 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.cyclonedx.exception.GeneratorException;
+import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.generators.BomGeneratorFactory;
+import org.cyclonedx.generators.json.BomJsonGenerator;
+import org.cyclonedx.generators.xml.BomXmlGenerator;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.Hash;
+import org.cyclonedx.model.Metadata;
+import org.cyclonedx.model.ReleaseNotes;
+import org.cyclonedx.model.Service;
+import org.cyclonedx.parsers.JsonParser;
+import org.cyclonedx.parsers.XmlParser;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.w3c.dom.Document;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that version-specific fields are correctly filtered when generating
+ * BOMs for older CycloneDX versions. A BOM populated with features from the
+ * latest version (1.7) must pass schema validation when generated for any
+ * supported target version.
+ *
+ * This test ensures that:
+ * <ul>
+ *   <li>{@code @VersionFilter} annotations on model fields cause automatic removal
+ *       by {@code CustomSerializerModifier} for classes using default Jackson serialization</li>
+ *   <li>Custom serializers (LicenseChoiceSerializer, ExternalReferenceSerializer, etc.)
+ *       properly check versions via {@code SerializerUtils.shouldSerializeField()}</li>
+ *   <li>Enum constants with {@code @VersionFilter} (ExternalReference.Type, Hash.Algorithm,
+ *       Component.Type) are filtered at serialization time</li>
+ * </ul>
+ */
+public class VersionFilteringTest {
+
+    /**
+     * Creates a BOM populated with features spanning all CycloneDX versions.
+     * Fields from newer versions should be automatically filtered out when
+     * generating for older versions.
+     */
+    private Bom createFullFeaturedBom() {
+        Bom bom = new Bom();
+        bom.setSerialNumber("urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79");
+
+        // Metadata with timestamp (v1.0+)
+        Metadata metadata = new Metadata();
+        metadata.setTimestamp(new Date());
+        bom.setMetadata(metadata);
+
+        // Component with v1.0+ fields
+        Component component = new Component();
+        component.setType(Component.Type.LIBRARY);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component.setPublisher("Acme Inc.");
+        component.setDescription("A test library");
+        component.setModified(false);
+
+        // bom-ref (v1.1+)
+        component.setBomRef("comp-1");
+
+        // ExternalReferences with types from various versions
+        List<ExternalReference> extRefs = new ArrayList<>();
+
+        // v1.0+ type
+        ExternalReference websiteRef = new ExternalReference();
+        websiteRef.setType(ExternalReference.Type.WEBSITE);
+        websiteRef.setUrl("https://example.com");
+        extRefs.add(websiteRef);
+
+        // v1.4+ type
+        ExternalReference releaseNotesRef = new ExternalReference();
+        releaseNotesRef.setType(ExternalReference.Type.RELEASE_NOTES);
+        releaseNotesRef.setUrl("https://example.com/releases");
+        extRefs.add(releaseNotesRef);
+
+        // v1.5+ type
+        ExternalReference attestationRef = new ExternalReference();
+        attestationRef.setType(ExternalReference.Type.ATTESTATION);
+        attestationRef.setUrl("https://example.com/attestation");
+        extRefs.add(attestationRef);
+
+        // v1.6+ type
+        ExternalReference sourceDistRef = new ExternalReference();
+        sourceDistRef.setType(ExternalReference.Type.SOURCE_DISTRIBUTION);
+        sourceDistRef.setUrl("https://example.com/source");
+        extRefs.add(sourceDistRef);
+
+        component.setExternalReferences(extRefs);
+
+        // Hashes (v1.0+)
+        List<Hash> hashes = new ArrayList<>();
+        hashes.add(new Hash(Hash.Algorithm.SHA_256,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"));
+        component.setHashes(hashes);
+
+        bom.setComponents(Collections.singletonList(component));
+
+        // Service with releaseNotes (v1.4+)
+        Service service = new Service();
+        service.setName("acme-service");
+        service.setBomRef("svc-1");
+        ReleaseNotes releaseNotes = new ReleaseNotes();
+        releaseNotes.setType("major");
+        releaseNotes.setTitle("v2.0");
+        service.setReleaseNotes(releaseNotes);
+        bom.setServices(Collections.singletonList(service));
+
+        return bom;
+    }
+
+    static Stream<Arguments> allXmlVersions() {
+        return Arrays.stream(Version.values())
+            .filter(v -> v.getFormats().contains(Format.XML))
+            .map(Arguments::of);
+    }
+
+    static Stream<Arguments> allJsonVersions() {
+        return Arrays.stream(Version.values())
+            .filter(v -> v.getFormats().contains(Format.JSON))
+            .map(Arguments::of);
+    }
+
+    @ParameterizedTest(name = "XML v{0}: full-featured BOM passes schema validation")
+    @MethodSource("allXmlVersions")
+    void xmlSchemaValidation(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(targetVersion, bom);
+        Document doc = generator.generate();
+
+        byte[] xmlBytes = generator.toXmlString().getBytes(StandardCharsets.UTF_8);
+        XmlParser parser = new XmlParser();
+        List<ParseException> errors = parser.validate(xmlBytes, targetVersion);
+
+        assertTrue(errors.isEmpty(),
+            String.format("XML v%s schema validation failed with %d error(s): %s",
+                targetVersion.getVersionString(), errors.size(),
+                errors.isEmpty() ? "" : errors.get(0).getMessage()));
+    }
+
+    @ParameterizedTest(name = "JSON v{0}: full-featured BOM passes schema validation")
+    @MethodSource("allJsonVersions")
+    void jsonSchemaValidation(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(targetVersion, bom);
+        String json = generator.toJsonString();
+
+        JsonParser parser = new JsonParser();
+        List<ParseException> errors = parser.validate(json.getBytes(StandardCharsets.UTF_8), targetVersion);
+
+        assertTrue(errors.isEmpty(),
+            String.format("JSON v%s schema validation failed with %d error(s): %s",
+                targetVersion.getVersionString(), errors.size(),
+                errors.isEmpty() ? "" : errors.get(0).getMessage()));
+    }
+
+    @ParameterizedTest(name = "XML v{0}: version-gated ExternalReference types are filtered")
+    @MethodSource("allXmlVersions")
+    void xmlExternalReferenceTypeFiltering(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(targetVersion, bom);
+        String xml = generator.toXmlString();
+
+        // externalReferences on Component are v1.1+ (VersionFilter(VERSION_11))
+        if (targetVersion.getVersion() >= Version.VERSION_11.getVersion()) {
+            // WEBSITE (v1.0+) should be present when externalReferences are supported
+            assertTrue(xml.contains("https://example.com"),
+                "WEBSITE reference should be present in v" + targetVersion.getVersionString());
+        }
+
+        // RELEASE_NOTES (v1.4+)
+        if (targetVersion.getVersion() < Version.VERSION_14.getVersion()) {
+            assertFalse(xml.contains("release-notes"),
+                "release-notes type should not appear in v" + targetVersion.getVersionString());
+        }
+
+        // ATTESTATION (v1.5+)
+        if (targetVersion.getVersion() < Version.VERSION_15.getVersion()) {
+            assertFalse(xml.contains("attestation"),
+                "attestation type should not appear in v" + targetVersion.getVersionString());
+        }
+
+        // SOURCE_DISTRIBUTION (v1.6+)
+        if (targetVersion.getVersion() < Version.VERSION_16.getVersion()) {
+            assertFalse(xml.contains("source-distribution"),
+                "source-distribution type should not appear in v" + targetVersion.getVersionString());
+        }
+    }
+
+    @ParameterizedTest(name = "JSON v{0}: version-gated ExternalReference types are filtered")
+    @MethodSource("allJsonVersions")
+    void jsonExternalReferenceTypeFiltering(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(targetVersion, bom);
+        String json = generator.toJsonString();
+
+        // WEBSITE (v1.0+) should always be present
+        assertTrue(json.contains("website"),
+            "WEBSITE reference should be present in v" + targetVersion.getVersionString());
+
+        // RELEASE_NOTES (v1.4+)
+        if (targetVersion.getVersion() < Version.VERSION_14.getVersion()) {
+            assertFalse(json.contains("release-notes"),
+                "release-notes type should not appear in v" + targetVersion.getVersionString());
+        }
+
+        // ATTESTATION (v1.5+)
+        if (targetVersion.getVersion() < Version.VERSION_15.getVersion()) {
+            assertFalse(json.contains("attestation"),
+                "attestation type should not appear in v" + targetVersion.getVersionString());
+        }
+
+        // SOURCE_DISTRIBUTION (v1.6+)
+        if (targetVersion.getVersion() < Version.VERSION_16.getVersion()) {
+            assertFalse(json.contains("source-distribution"),
+                "source-distribution type should not appear in v" + targetVersion.getVersionString());
+        }
+    }
+
+    @ParameterizedTest(name = "JSON v{0}: Service.releaseNotes filtered before v1.4")
+    @MethodSource("allJsonVersions")
+    void jsonServiceReleaseNotesFiltering(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(targetVersion, bom);
+        String json = generator.toJsonString();
+
+        if (targetVersion.getVersion() < Version.VERSION_14.getVersion()) {
+            assertFalse(json.contains("releaseNotes"),
+                "releaseNotes should not appear in JSON v" + targetVersion.getVersionString());
+        } else {
+            assertTrue(json.contains("releaseNotes"),
+                "releaseNotes should appear in JSON v" + targetVersion.getVersionString());
+        }
+    }
+
+    @ParameterizedTest(name = "XML v{0}: Component.bomRef filtered before v1.1")
+    @MethodSource("allXmlVersions")
+    void xmlComponentBomRefFiltering(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(targetVersion, bom);
+        String xml = generator.toXmlString();
+
+        if (targetVersion.getVersion() < Version.VERSION_11.getVersion()) {
+            assertFalse(xml.contains("bom-ref"),
+                "bom-ref should not appear in XML v" + targetVersion.getVersionString());
+        } else {
+            assertTrue(xml.contains("bom-ref"),
+                "bom-ref should appear in XML v" + targetVersion.getVersionString());
+        }
+    }
+
+    @ParameterizedTest(name = "JSON v{0}: Component.bomRef filtered before v1.1")
+    @MethodSource("allJsonVersions")
+    void jsonComponentBomRefFiltering(Version targetVersion) throws Exception {
+        Bom bom = createFullFeaturedBom();
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(targetVersion, bom);
+        String json = generator.toJsonString();
+
+        // JSON starts at v1.2, so bom-ref should always be present
+        assertTrue(json.contains("bom-ref"),
+            "bom-ref should appear in JSON v" + targetVersion.getVersionString());
+    }
+}

--- a/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
@@ -24,6 +24,7 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Component.Type;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.TlpClassification;
 import org.cyclonedx.model.License;
 import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.OrganizationalEntity;
@@ -65,6 +66,11 @@ import org.cyclonedx.model.license.Acknowledgement;
 import org.cyclonedx.model.license.Expression;
 import org.cyclonedx.model.license.ExpressionDetailed;
 import org.cyclonedx.model.license.ExpressionDetail;
+import org.cyclonedx.model.Citation;
+import org.cyclonedx.model.Patent;
+import org.cyclonedx.model.PatentFamily;
+import org.cyclonedx.model.PatentAssertion;
+import org.cyclonedx.model.PatentItem;
 import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.ArrayList;
@@ -840,5 +846,194 @@ public class JsonParserTest
     public void testIssue492Regression() throws Exception {
         final Bom bom = getJsonBom("regression/issue492.json");
         assertEquals(2, bom.getMetadata().getTools().size());
+    }
+
+    // ==================== CycloneDX 1.7 Citation Tests ====================
+
+    @Test
+    public void schema17_citations() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-citations-1.7.json");
+
+        assertNotNull(bom.getCitations());
+        assertEquals(4, bom.getCitations().size());
+
+        // Citation 1: pointers + attributedTo
+        Citation c1 = bom.getCitations().get(0);
+        assertEquals("citation-1", c1.getBomRef());
+        assertNotNull(c1.getPointers());
+        assertEquals(1, c1.getPointers().size());
+        assertEquals("/components/0/name", c1.getPointers().get(0));
+        assertNotNull(c1.getTimestamp());
+        assertEquals("person-1", c1.getAttributedTo());
+        assertNull(c1.getProcess());
+        assertNotNull(c1.getNote());
+
+        // Citation 2: pointers + process
+        Citation c2 = bom.getCitations().get(1);
+        assertEquals("citation-2", c2.getBomRef());
+        assertNotNull(c2.getPointers());
+        assertEquals("task-license-scan", c2.getProcess());
+        assertNull(c2.getAttributedTo());
+
+        // Citation 3: expressions + process
+        Citation c3 = bom.getCitations().get(2);
+        assertEquals("citation-3", c3.getBomRef());
+        assertNotNull(c3.getExpressions());
+        assertEquals(1, c3.getExpressions().size());
+        assertNull(c3.getPointers());
+
+        // Citation 4: expressions + attributedTo + process
+        Citation c4 = bom.getCitations().get(3);
+        assertEquals("citation-4", c4.getBomRef());
+        assertNotNull(c4.getExpressions());
+        assertEquals("scan-tool-1", c4.getAttributedTo());
+        assertEquals("task-license-scan", c4.getProcess());
+    }
+
+    // ==================== CycloneDX 1.7 External Component Tests ====================
+
+    @Test
+    public void schema17_component_external_with_versionRange() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-component-external-with-versionRange.json");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("libcurl", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertEquals("vers:generic/>=8.7.1|<9.0.0", c.getVersionRange());
+        assertNull(c.getVersion());
+        assertEquals("libcurl ^8.7.1", c.getDescription());
+    }
+
+    @Test
+    public void schema17_component_external_with_version() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-component-external-with-version.json");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("Ubuntu", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertEquals("24.04", c.getVersion());
+        assertNull(c.getVersionRange());
+    }
+
+    @Test
+    public void schema17_component_external_without_version() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-component-external-without-version.json");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("Windows 11 (64bit)", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertNull(c.getVersion());
+        assertNull(c.getVersionRange());
+    }
+
+    @Test
+    public void schema17_external_reference_properties() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-external-reference-properties-1.7.json");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertNotNull(c.getExternalReferences());
+        assertEquals(1, c.getExternalReferences().size());
+
+        ExternalReference ref = c.getExternalReferences().get(0);
+        assertEquals(ExternalReference.Type.COMPONENT_ANALYSIS_REPORT, ref.getType());
+        assertEquals("http://example.com/extref/component-analysis-report", ref.getUrl());
+        assertNotNull(ref.getProperties());
+        assertEquals(2, ref.getProperties().size());
+        assertEquals("author", ref.getProperties().get(0).getName());
+        assertEquals("John Doe", ref.getProperties().get(0).getValue());
+        assertEquals("timestamp", ref.getProperties().get(1).getName());
+    }
+
+    @Test
+    public void schema17_metadata_distribution() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-metadata-distribution-1.7.json");
+
+        assertNotNull(bom.getMetadata());
+        assertNotNull(bom.getMetadata().getDistributionConstraints());
+        assertEquals(TlpClassification.RED, bom.getMetadata().getDistributionConstraints().getTlp());
+    }
+
+    // ==================== CycloneDX 1.7 Patent Tests ====================
+
+    @Test
+    public void schema17_patent() throws Exception {
+        final Bom bom = getJsonBom("1.7/valid-patent-1.7.json");
+
+        // Definitions patents
+        assertNotNull(bom.getDefinitions());
+        assertNotNull(bom.getDefinitions().getPatents());
+        assertEquals(4, bom.getDefinitions().getPatents().size());
+
+        // First 3 are patents
+        PatentItem item1 = bom.getDefinitions().getPatents().get(0);
+        assertNotNull(item1.getPatent());
+        assertNull(item1.getPatentFamily());
+        Patent p1 = item1.getPatent();
+        assertEquals("patent-1", p1.getBomRef());
+        assertEquals("US1234567890", p1.getPatentNumber());
+        assertEquals("US", p1.getJurisdiction());
+        assertEquals("Efficient Data Processing Algorithm", p1.getTitle());
+        assertNotNull(p1.getFilingDate());
+        assertNotNull(p1.getGrantDate());
+        assertEquals(Patent.PatentLegalStatus.IN_FORCE, p1.getPatentLegalStatus());
+        assertNotNull(p1.getPatentAssignee());
+        assertEquals(1, p1.getPatentAssignee().size());
+        assertNotNull(p1.getExternalReferences());
+        assertEquals(1, p1.getExternalReferences().size());
+        assertEquals(ExternalReference.Type.PATENT, p1.getExternalReferences().get(0).getType());
+
+        // Patent 2 has priority application
+        Patent p2 = bom.getDefinitions().getPatents().get(1).getPatent();
+        assertEquals("patent-2", p2.getBomRef());
+        assertNotNull(p2.getPriorityApplication());
+        assertEquals("US1234567890", p2.getPriorityApplication().getApplicationNumber());
+        assertEquals("US", p2.getPriorityApplication().getJurisdiction());
+
+        // Fourth is a patent family
+        PatentItem item4 = bom.getDefinitions().getPatents().get(3);
+        assertNull(item4.getPatent());
+        assertNotNull(item4.getPatentFamily());
+        PatentFamily pf = item4.getPatentFamily();
+        assertEquals("patent-family-1", pf.getBomRef());
+        assertEquals("PF-2023001", pf.getFamilyId());
+        assertNotNull(pf.getMembers());
+        assertEquals(2, pf.getMembers().size());
+        assertTrue(pf.getMembers().contains("patent-1"));
+        assertTrue(pf.getMembers().contains("patent-2"));
+        assertNotNull(pf.getExternalReferences());
+        assertEquals(ExternalReference.Type.PATENT_FAMILY, pf.getExternalReferences().get(0).getType());
+
+        // Component patent assertions
+        assertNotNull(bom.getComponents());
+        Component comp = bom.getComponents().get(0);
+        assertNotNull(comp.getPatentAssertions());
+        assertEquals(2, comp.getPatentAssertions().size());
+        PatentAssertion pa1 = comp.getPatentAssertions().get(0);
+        assertEquals("patent-assertion-1", pa1.getBomRef());
+        assertEquals(PatentAssertion.AssertionType.OWNERSHIP, pa1.getAssertionType());
+        assertEquals(1, pa1.getPatentRefs().size());
+        assertEquals("patent-1", pa1.getPatentRefs().get(0));
+
+        PatentAssertion pa2 = comp.getPatentAssertions().get(1);
+        assertEquals(PatentAssertion.AssertionType.LICENSE, pa2.getAssertionType());
+
+        // Service patent assertions
+        assertNotNull(bom.getServices());
+        assertNotNull(bom.getServices().get(0).getPatentAssertions());
+        assertEquals(1, bom.getServices().get(0).getPatentAssertions().size());
+        PatentAssertion pa3 = bom.getServices().get(0).getPatentAssertions().get(0);
+        assertEquals(PatentAssertion.AssertionType.EXCLUSIVE_RIGHTS, pa3.getAssertionType());
     }
 }

--- a/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
@@ -26,6 +26,7 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Component.Type;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.TlpClassification;
 import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Pedigree;
@@ -67,6 +68,11 @@ import org.cyclonedx.model.license.Acknowledgement;
 import org.cyclonedx.model.license.Expression;
 import org.cyclonedx.model.license.ExpressionDetailed;
 import org.cyclonedx.model.license.ExpressionDetail;
+import org.cyclonedx.model.Citation;
+import org.cyclonedx.model.Patent;
+import org.cyclonedx.model.PatentFamily;
+import org.cyclonedx.model.PatentAssertion;
+import org.cyclonedx.model.PatentItem;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -993,6 +999,176 @@ public class XmlParserTest
     public void testIssue492Regression() throws Exception {
         final Bom bom = getXmlBom("regression/issue492.xml");
         assertEquals(2, bom.getMetadata().getTools().size());
+    }
+
+    // ==================== CycloneDX 1.7 Citation Tests ====================
+
+    @Test
+    public void schema17_citations() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-citations-1.7.xml");
+
+        assertNotNull(bom.getCitations());
+        assertEquals(4, bom.getCitations().size());
+
+        // Citation 1: pointers + attributedTo
+        Citation c1 = bom.getCitations().get(0);
+        assertEquals("citation-1", c1.getBomRef());
+        assertNotNull(c1.getPointers());
+        assertEquals(1, c1.getPointers().size());
+        assertEquals("/components/0/name", c1.getPointers().get(0));
+        assertNotNull(c1.getTimestamp());
+        assertEquals("person-1", c1.getAttributedTo());
+        assertNotNull(c1.getNote());
+
+        // Citation 4: expressions + attributedTo + process
+        Citation c4 = bom.getCitations().get(3);
+        assertEquals("citation-4", c4.getBomRef());
+        assertNotNull(c4.getExpressions());
+        assertEquals(1, c4.getExpressions().size());
+        assertEquals("scan-tool-1", c4.getAttributedTo());
+        assertEquals("task-license-scan", c4.getProcess());
+    }
+
+    // ==================== CycloneDX 1.7 External Component Tests ====================
+
+    @Test
+    public void schema17_component_external_with_versionRange() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-component-external-with-versionRange.xml");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("libcurl", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertEquals("vers:generic/>=8.7.1|<9.0.0", c.getVersionRange());
+        assertNull(c.getVersion());
+        assertEquals("libcurl ^8.7.1", c.getDescription());
+    }
+
+    @Test
+    public void schema17_component_external_with_version() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-component-external-with-version.xml");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("Ubuntu", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertEquals("24H2", c.getVersion());
+        assertNull(c.getVersionRange());
+    }
+
+    @Test
+    public void schema17_component_external_without_version() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-component-external-without-version.xml");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertEquals("Windows 11 (64bit)", c.getName());
+        assertEquals(true, c.getIsExternal());
+        assertNull(c.getVersion());
+        assertNull(c.getVersionRange());
+    }
+
+    @Test
+    public void schema17_external_reference_properties() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-external-reference-properties-1.7.xml");
+
+        assertNotNull(bom.getComponents());
+        assertEquals(1, bom.getComponents().size());
+
+        Component c = bom.getComponents().get(0);
+        assertNotNull(c.getExternalReferences());
+        assertEquals(1, c.getExternalReferences().size());
+
+        ExternalReference ref = c.getExternalReferences().get(0);
+        assertEquals(ExternalReference.Type.COMPONENT_ANALYSIS_REPORT, ref.getType());
+        assertNotNull(ref.getProperties());
+        assertEquals(2, ref.getProperties().size());
+        assertEquals("author", ref.getProperties().get(0).getName());
+        assertEquals("John Doe", ref.getProperties().get(0).getValue());
+    }
+
+    @Test
+    public void schema17_metadata_distribution() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-metadata-distribution-1.7.xml");
+
+        assertNotNull(bom.getMetadata());
+        assertNotNull(bom.getMetadata().getDistributionConstraints());
+        assertEquals(TlpClassification.RED, bom.getMetadata().getDistributionConstraints().getTlp());
+    }
+
+    // ==================== CycloneDX 1.7 Patent Tests ====================
+
+    @Test
+    public void schema17_patent() throws Exception {
+        final Bom bom = getXmlBom("1.7/valid-patent-1.7.xml");
+
+        // Definitions patents
+        assertNotNull(bom.getDefinitions());
+        assertNotNull(bom.getDefinitions().getPatents());
+        assertEquals(4, bom.getDefinitions().getPatents().size());
+
+        // First 3 are patents
+        PatentItem item1 = bom.getDefinitions().getPatents().get(0);
+        assertNotNull(item1.getPatent());
+        assertNull(item1.getPatentFamily());
+        Patent p1 = item1.getPatent();
+        assertEquals("patent-1", p1.getBomRef());
+        assertEquals("US1234567890", p1.getPatentNumber());
+        assertEquals("US", p1.getJurisdiction());
+        assertEquals("Efficient Data Processing Algorithm", p1.getTitle());
+        assertNotNull(p1.getFilingDate());
+        assertNotNull(p1.getGrantDate());
+        assertEquals(Patent.PatentLegalStatus.IN_FORCE, p1.getPatentLegalStatus());
+        assertNotNull(p1.getPatentAssignee());
+        assertEquals(1, p1.getPatentAssignee().size());
+        assertNotNull(p1.getExternalReferences());
+        assertEquals(1, p1.getExternalReferences().size());
+        assertEquals(ExternalReference.Type.PATENT, p1.getExternalReferences().get(0).getType());
+
+        // Patent 2 has priority application
+        Patent p2 = bom.getDefinitions().getPatents().get(1).getPatent();
+        assertEquals("patent-2", p2.getBomRef());
+        assertNotNull(p2.getPriorityApplication());
+        assertEquals("US1234567890", p2.getPriorityApplication().getApplicationNumber());
+        assertEquals("US", p2.getPriorityApplication().getJurisdiction());
+
+        // Fourth is a patent family
+        PatentItem item4 = bom.getDefinitions().getPatents().get(3);
+        assertNull(item4.getPatent());
+        assertNotNull(item4.getPatentFamily());
+        PatentFamily pf = item4.getPatentFamily();
+        assertEquals("patent-family-1", pf.getBomRef());
+        assertEquals("PF-2023001", pf.getFamilyId());
+        assertNotNull(pf.getMembers());
+        assertEquals(2, pf.getMembers().size());
+        assertTrue(pf.getMembers().contains("patent-1"));
+        assertTrue(pf.getMembers().contains("patent-2"));
+        assertNotNull(pf.getExternalReferences());
+        assertEquals(ExternalReference.Type.PATENT_FAMILY, pf.getExternalReferences().get(0).getType());
+
+        // Component patent assertions
+        assertNotNull(bom.getComponents());
+        Component comp = bom.getComponents().get(0);
+        assertNotNull(comp.getPatentAssertions());
+        assertEquals(2, comp.getPatentAssertions().size());
+        PatentAssertion pa1 = comp.getPatentAssertions().get(0);
+        assertEquals("patent-assertion-1", pa1.getBomRef());
+        assertEquals(PatentAssertion.AssertionType.OWNERSHIP, pa1.getAssertionType());
+        assertEquals(1, pa1.getPatentRefs().size());
+        assertEquals("patent-1", pa1.getPatentRefs().get(0));
+
+        // Service patent assertions
+        assertNotNull(bom.getServices());
+        assertNotNull(bom.getServices().get(0).getPatentAssertions());
+        assertEquals(1, bom.getServices().get(0).getPatentAssertions().size());
+        PatentAssertion pa3 = bom.getServices().get(0).getPatentAssertions().get(0);
+        assertEquals(PatentAssertion.AssertionType.EXCLUSIVE_RIGHTS, pa3.getAssertionType());
     }
 
     @Test

--- a/src/test/resources/1.7/valid-citations-1.7.json
+++ b/src/test/resources/1.7/valid-citations-1.7.json
@@ -69,7 +69,7 @@
           "name": "My Scan Tool"
         }
       ],
-      "bom-ref": "workflow-1",
+      "bom-ref": "formula-1",
       "workflows": [
         {
           "bom-ref": "workflow-1",


### PR DESCRIPTION
Add polymorphic patent support and make serialization version-aware. Introduces PatentItem model plus PatentItemDeserializer, PatentsDeserializer and PatentAssertionDeserializer/Serializer to handle mixed Patent/PatentFamily entries and XML/JSON differences; updates Definition to use the polymorphic list and provides helpers for legacy access. Refactors many serializers (EnvironmentVars, InputType, ExternalReference, Hash, IkeV2Transform, etc.) and CustomSerializerModifier to honor @VersionFilter and a Version parameter, filters enum/field serialization by target BOM version, and normalizes date formatting. Also enhances OrganizationalChoice deserialization, adds properties handling to ExternalReferencesDeserializer, and small model tweaks (Component, Composition, Service, LicenseItem, PriorityApplication, FormulationCommon, Level) to align with newer schema versions.