### PR TITLE
Add CycloneDX 1.7 crypto tests; reorder JSON props

### DIFF
--- a/src/main/java/org/cyclonedx/model/component/crypto/AlgorithmProperties.java
+++ b/src/main/java/org/cyclonedx/model/component/crypto/AlgorithmProperties.java
@@ -23,10 +23,10 @@ import org.cyclonedx.model.component.crypto.enums.Primitive;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({
     "primitive",
-    "parameterSetIdentifier",
     "algorithmFamily",
-    "ellipticCurve",
+    "parameterSetIdentifier",
     "curve",
+    "ellipticCurve",
     "executionEnvironment",
     "implementationPlatform",
     "certificationLevel",

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -952,6 +952,80 @@ public class BomJsonGeneratorTest {
         assertTrue(parser.isValid(loadedFile, version));
     }
 
+    // ==================== CycloneDX 1.7 Cryptography Tests ====================
+
+    @Test
+    public void schema17_testCryptographyFull() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-full-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyFull_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-cryptography-full-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyCertificateAdvanced() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-certificate-advanced-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyCertificateAdvanced_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-cryptography-certificate-advanced-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyImplementation() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-implementation-1.7.json");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyImplementation_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonXmlBom("/1.7/valid-cryptography-implementation-1.7.xml");
+
+        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        File loadedFile = writeToFile(generator.toJsonString());
+
+        JsonParser parser = new JsonParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
     private void assertExternalReferenceInfo(Bom bom) {
         assertEquals(3, bom.getExternalReferences().size());
         assertEquals(3, bom.getComponents().get(0).getExternalReferences().size());

--- a/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
@@ -1141,6 +1141,80 @@ public class BomXmlGeneratorTest {
         assertTrue(parser.isValid(loadedFile, version));
     }
 
+    // ==================== CycloneDX 1.7 Cryptography Tests ====================
+
+    @Test
+    public void schema17_testCryptographyFull() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-full-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyFull_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-cryptography-full-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyCertificateAdvanced() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-certificate-advanced-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyCertificateAdvanced_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-cryptography-certificate-advanced-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyImplementation() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonJsonBom("/1.7/valid-cryptography-implementation-1.7.json");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
+    @Test
+    public void schema17_testCryptographyImplementation_xml() throws Exception {
+        Version version = Version.VERSION_17;
+        Bom bom = createCommonBomXml("/1.7/valid-cryptography-implementation-1.7.xml");
+
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
+
+        XmlParser parser = new XmlParser();
+        assertTrue(parser.isValid(loadedFile, version));
+    }
+
     private void assertExternalReferenceInfo(Bom bom) {
         assertEquals(3, bom.getExternalReferences().size());
         assertEquals(3, bom.getComponents().get(0).getExternalReferences().size());

--- a/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
+++ b/src/test/java/org/cyclonedx/schema/JsonSchemaVerificationTest.java
@@ -55,6 +55,9 @@ public class JsonSchemaVerificationTest extends BaseSchemaVerificationTest {
                 else if (file.endsWith("-1.6.json")) {
                     schemaVersion = Version.VERSION_16;
                 }
+                else if (file.endsWith("-1.7.json")) {
+                    schemaVersion = Version.VERSION_17;
+                }
                 else {
                     schemaVersion = null;
                 }

--- a/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
+++ b/src/test/java/org/cyclonedx/schema/XmlSchemaVerificationTest.java
@@ -62,6 +62,9 @@ public class XmlSchemaVerificationTest extends BaseSchemaVerificationTest {
                 else if (file.endsWith("-1.6.xml")) {
                     schemaVersion = Version.VERSION_16;
                 }
+                else if (file.endsWith("-1.7.xml")) {
+                    schemaVersion = Version.VERSION_17;
+                }
                 else {
                     schemaVersion = null;
                 }


### PR DESCRIPTION
Add comprehensive CycloneDX 1.7 cryptography unit tests for both JSON and XML generators (updates to BomJsonGeneratorTest and BomXmlGeneratorTest). Update schema verification to recognize -1.7 fixtures in JsonSchemaVerificationTest and XmlSchemaVerificationTest. Adjust AlgorithmProperties@JsonPropertyOrder to change the ordering of parameterSetIdentifier, curve, and ellipticCurve to match the 1.7 schema expectations.