### PR TITLE
fix: register CycloneDX annotation keywords to silence schema validator warnings

### DIFF
--- a/src/main/java/org/cyclonedx/CycloneDxSchema.java
+++ b/src/main/java/org/cyclonedx/CycloneDxSchema.java
@@ -22,6 +22,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.dialect.DefaultDialectRegistry;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.DialectId;
+import com.networknt.schema.dialect.DialectRegistry;
+import com.networknt.schema.dialect.Draft7;
+import com.networknt.schema.keyword.NonValidationKeyword;
 import com.networknt.schema.serialization.DefaultNodeReader;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
@@ -96,12 +102,37 @@ public abstract class CycloneDxSchema
     offlineMappings.put("http://cyclonedx.org/schema/bom-1.6.schema.json", "classpath:bom-1.6.schema.json");
 
     JsonNode schemaNode = mapper.readTree(spdxInstream);
+    final Dialect cycloneDxDialect = getCycloneDxJsonDialect();
+    final DialectRegistry defaultDialectRegistry = new DefaultDialectRegistry();
+    final DialectRegistry dialectRegistry = (dialectId, schemaRegistry) ->
+        DialectId.DRAFT_7.equals(dialectId)
+            ? cycloneDxDialect
+            : defaultDialectRegistry.getDialect(dialectId, schemaRegistry);
     SchemaRegistry registry = SchemaRegistry.builder()
         .nodeReader(DefaultNodeReader.builder().jsonMapper(mapper).build())
         .schemaIdResolvers(b -> b.mappings(offlineMappings))
         .schemaRegistryConfig(config)
+        .dialectRegistry(dialectRegistry)
         .build();
     return registry.getSchema(schemaNode);
+  }
+
+  /**
+   * Returns the JSON schema dialect used to interpret the CycloneDX JSON schemas.
+   * <p>
+   * The CycloneDX JSON schemas declare the draft-07 dialect but make use of the
+   * CycloneDX-specific {@code meta:enum} and {@code deprecated} annotation keywords,
+   * which are not part of draft-07. They are registered here as non-validating
+   * keywords so the underlying validator does not emit "Unknown keyword" warnings.
+   * The keywords carry no validation semantics, so validation behaviour is unchanged.
+   *
+   * @return a draft-07 based dialect that recognises the CycloneDX annotation keywords
+   */
+  static Dialect getCycloneDxJsonDialect() {
+    return Dialect.builder(Draft7.getInstance())
+        .keyword(new NonValidationKeyword("meta:enum"))
+        .keyword(new NonValidationKeyword("deprecated"))
+        .build();
   }
 
   private InputStream getJsonSchemaAsStream(final Version schemaVersion) {

--- a/src/test/java/org/cyclonedx/CycloneDxJsonDialectTest.java
+++ b/src/test/java/org/cyclonedx/CycloneDxJsonDialectTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx;
+
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Draft7;
+import com.networknt.schema.keyword.Keyword;
+import com.networknt.schema.keyword.NonValidationKeyword;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the CycloneDX JSON dialect registers the CycloneDX-specific
+ * {@code meta:enum} and {@code deprecated} annotation keywords.
+ * <p>
+ * The CycloneDX 1.6 JSON schema declares the draft-07 dialect but uses these
+ * two
+ * keywords, which are not part of draft-07. Without registering them the
+ * underlying
+ * {@code json-schema-validator} logs a "Unknown keyword" warning for each one.
+ * Treating
+ * them as {@link NonValidationKeyword}s keeps validation behaviour unchanged
+ * while
+ * suppressing the warnings.
+ */
+class CycloneDxJsonDialectTest {
+
+    @Test
+    void registersCycloneDxAnnotationKeywordsAsNonValidating() {
+        final Map<String, Keyword> keywords = CycloneDxSchema.getCycloneDxJsonDialect().getKeywords();
+
+        assertThat(keywords).containsKey("meta:enum");
+        assertThat(keywords).containsKey("deprecated");
+        assertThat(keywords.get("meta:enum")).isInstanceOf(NonValidationKeyword.class);
+        assertThat(keywords.get("deprecated")).isInstanceOf(NonValidationKeyword.class);
+    }
+
+    @Test
+    void stockDraft7DialectDoesNotKnowCycloneDxKeywords() {
+        // Guards against the fix becoming redundant: if upstream ever adds these
+        // keywords
+        // to draft-07 this assertion fails, signalling the custom dialect can be
+        // removed.
+        final Map<String, Keyword> keywords = Draft7.getInstance().getKeywords();
+
+        assertThat(keywords).doesNotContainKey("meta:enum");
+        assertThat(keywords).doesNotContainKey("deprecated");
+    }
+
+    @Test
+    void validatesValid16BomWithCustomDialect() throws Exception {
+        final File bom = new File(
+                Objects.requireNonNull(getClass().getResource("/1.6/valid-bom-1.6.json")).getFile());
+
+        assertThat(new JsonParser().isValid(bom, Version.VERSION_16)).isTrue();
+    }
+}


### PR DESCRIPTION
## Reference
Addresses the long-standing warning reported in CycloneDX/cyclonedx-maven-plugin#564.

## Problem
The CycloneDX JSON schemas (e.g. `bom-1.6.schema.json`) declare the JSON-Schema **draft-07** dialect but use the CycloneDX-proprietary annotation keywords `meta:enum` and `deprecated`, which are not part of draft-07. When a consumer has an SLF4J backend on the classpath, the networknt json-schema-validator logs:

```
Unknown keyword meta:enum - you should define your own Meta Schema...
Unknown keyword deprecated - you should define your own Meta Schema...
```

once per keyword during BOM validation. This is noise for every downstream tool (e.g. the Maven plugin).

## Fix
Derive a draft-07 dialect that registers `meta:enum` and `deprecated` as `NonValidationKeyword`s and wire it in via a delegating `DialectRegistry` on the `SchemaRegistry` used for CycloneDX schemas. The keywords are pure annotations, so validation behaviour is unchanged — only the spurious warnings are removed.

## Tests
- New `CycloneDxJsonDialectTest` verifying the keywords are registered as non-validating, that stock draft-07 does not know them, and that a valid 1.6 BOM still validates.
- Full suite green: **1182 tests, 0 failures, 0 errors**.
- End-to-end check with an SLF4J backend present: **0 "Unknown keyword"** warnings on this branch.
