### PR TITLE
Dependabot: don't suggest major version updates for json-schema-validator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    ignore:
+      # json-schema-validator v3 requires Java 17 and Jackson 3
+      # Remove once the project fulfills these preconditions.
+      - dependency-name: "com.networknt:json-schema-validator"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Version 3 of the lib requires a Java 17 baseline and Jackson 3, which cyclonedx-core-java can't currently fulfill. Dependabot raising PRs for major versions silently hides PRs for patch versions.