### PR TITLE
Expose non-pretty printed XML generation

### DIFF
--- a/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
@@ -133,6 +133,10 @@ public class BomXmlGenerator extends AbstractBomGenerator
         return toXML(bom, true);
     }
 
+    public String toXmlString(boolean prettyPrint) throws GeneratorException {
+        return toXML(bom, prettyPrint);
+    }
+
     /**
      * Creates a text representation of a CycloneDX BoM Document. This method calls {@link #toXmlString()} and will return
      * an empty string if {@link #toXmlString()} throws an exception. It's preferred to call {@link #toXmlString()}

--- a/src/main/java/org/cyclonedx/util/serializer/PropertiesSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/PropertiesSerializer.java
@@ -53,11 +53,11 @@ public class PropertiesSerializer
   private static void serializeXml(final List<Property> properties, final ToXmlGenerator xmlGenerator)
       throws IOException
   {
-    xmlGenerator.writeStartArray();
+    // NB - In this context Jackson already knows we're producing <property> elements so no need to explicitly try and
+    //      write the property field name otherwise we end up with malformed XML with double wrapped <property> elements
     for (Property property : properties) {
-      SerializerUtils.serializeProperty("property", property, xmlGenerator);
+      SerializerUtils.serializeProperty(null, property, xmlGenerator);
     }
-    xmlGenerator.writeEndArray();
   }
 
   @Override

--- a/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
+++ b/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Hash;
@@ -141,7 +142,9 @@ public class SerializerUtils
   }
 
   public static void serializeProperty(String propertyName,  Property prop, ToXmlGenerator xmlGenerator) throws IOException {
-    xmlGenerator.writeFieldName(propertyName);
+    if (StringUtils.isNotBlank(propertyName)) {
+      xmlGenerator.writeFieldName(propertyName);
+    }
     xmlGenerator.writeStartObject();
     xmlGenerator.setNextIsAttribute(true);
     xmlGenerator.writeFieldName("name");

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -145,6 +145,7 @@ public class BomJsonGeneratorTest {
 
     static Stream<Arguments> testData() {
         return Stream.of(
+            Arguments.of(Version.VERSION_17, "/1.7/valid-bom-1.7.xml"),
             Arguments.of(Version.VERSION_16, "/1.6/valid-bom-1.6.xml"),
             Arguments.of(Version.VERSION_15, "/bom-1.5.xml"),
             Arguments.of(Version.VERSION_14, "/bom-1.4.xml"),
@@ -165,6 +166,13 @@ public class BomJsonGeneratorTest {
         File file = writeToFile(generator.toJsonString());
         JsonParser parser = new JsonParser();
         assertTrue(parser.isValid(file, version));
+
+        // Verify that with pretty printing disabled the output JSON is smaller
+        long prettyPrintedSize = file.length();
+        file = writeToFile(generator.toJsonString(false));
+        assertTrue(parser.isValid(file, version));
+        assertTrue(file.length() < prettyPrintedSize,
+                   "Non pretty-printed output size should be smaller than pretty printed output size");
     }
 
     @Test

--- a/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
@@ -182,6 +182,7 @@ public class BomXmlGeneratorTest {
 
     static Stream<Arguments> testData() {
         return Stream.of(
+            Arguments.of(Version.VERSION_17, "/1.7/valid-bom-1.7.json"),
             Arguments.of(Version.VERSION_16, "/1.6/valid-bom-1.6.json"),
             Arguments.of(Version.VERSION_15, "/bom-1.5.json"),
             Arguments.of(Version.VERSION_14, "/bom-1.4.json"),
@@ -191,17 +192,24 @@ public class BomXmlGeneratorTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    public void testXmlGeneration(Version version, String bomXmlPath)
+    public void testXmlGeneration(Version version, String bomJsonPath)
         throws Exception
     {
-        Bom bom = createCommonJsonBom(bomXmlPath);
-        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
+        Bom bom = createCommonJsonBom(bomJsonPath);
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
 
         assertEquals(version, generator.getSchemaVersion());
 
-        File file = writeToFile(generator.toJsonString());
-        JsonParser parser = new JsonParser();
+        File file = writeToFile(generator.toXmlString());
+        XmlParser parser = new XmlParser();
         assertTrue(parser.isValid(file, version));
+
+        // Verify that with pretty printing disabled the output XML is smaller
+        long prettyPrintedSize = file.length();
+        file = writeToFile(generator.toXmlString(false));
+        assertTrue(parser.isValid(file, version));
+        assertTrue(file.length() < prettyPrintedSize,
+                   "Non pretty-printed output size should be smaller than pretty printed output size");
     }
 
     @Test
@@ -825,10 +833,10 @@ public class BomXmlGeneratorTest {
         component.setType(Type.APPLICATION);
         bom.getMetadata().getToolChoice().getComponents().add(component);
 
-        BomJsonGenerator generator = BomGeneratorFactory.createJson(version, bom);
-        File loadedFile = writeToFile(generator.toJsonString());
+        BomXmlGenerator generator = BomGeneratorFactory.createXml(version, bom);
+        File loadedFile = writeToFile(generator.toXmlString());
 
-        JsonParser parser = new JsonParser();
+        XmlParser parser = new XmlParser();
         assertTrue(parser.isValid(loadedFile, version));
     }
 

--- a/src/test/resources/bom-1.5.json
+++ b/src/test/resources/bom-1.5.json
@@ -905,7 +905,7 @@
           "timeEnd": "2023-01-01T00:00:00+10:00",
           "workspaces": [
             {
-              "bom-ref": "workspace-1",
+              "bom-ref": "workspace-2",
               "uid": "workspace-1",
               "name": "My workspace",
               "aliases": [ "default-workspace" ],
@@ -941,6 +941,10 @@
           "properties": [
             {
               "name": "Foo",
+              "value": "Bar"
+            },
+            {
+              "name": "Another",
               "value": "Bar"
             }
           ]

--- a/src/test/resources/bom-1.5.xml
+++ b/src/test/resources/bom-1.5.xml
@@ -737,6 +737,7 @@
                     </runtimeTopology>
                     <properties>
                         <property name="Foo">Bar</property>
+                        <property name="Another">Bar</property>
                     </properties>
                 </workflow>
             </workflows>


### PR DESCRIPTION
# Context

CycloneDX SBOMs contain a lot of information (by design) which for small modules with large dependency trees can actually lead to the SBOM being the largest artefact in a module by some margin.  With Maven Central planning to bring in [publishing limits](https://central.sonatype.org/publish/maven-central-publishing-limits/#maven-central-publishing-limits) we've been deep auditing what our open source releases produce to reduce unnecessary publishing and try to keep within the proposed size limit (80MB/month) as much as possible.

Once we eliminate the more obvious things that we shouldn't be publishing to Maven Central (e.g. fat JARs for local dev testing/tools, `tests` JARs for modules with no reusable test harnesses etc.) the SBOMs remain the largest contributor to release size.  For example on one large multi-module repository the SBOMs are the biggest artefact for over half of our modules and represent approximately 1/3 of total released bytes.

If we were able to generate non-pretty printed versions of the SBOMs (since ultimately SBOMs are for machine/tool consumption anyway) then some basic testing with tools like `jq` shows we could save up to 150 kilobytes per SBOM.  For a large multi-module project that adds up to megabytes of savings, which when we're talking about an 80MB/month publishing limit is not insignificant.  We use the Cyclone DX Maven Plugin, which in turns uses the library from this repository so the first step in exposing this capability in the plugin is to expose it in the library.  See related PR CycloneDX/cyclonedx-maven-plugin#668

This PR exposes that capability in the API where it wasn't previously exposed and ensures that there are more tests exercising the non-pretty printing code path.

# Code Changes

`BomXmlGenerator` has the ability to generate non pretty printed XML on a package private method but this was not exposed on the public API as it was for `BomJsonGenerator`.  `BomXmlGenerator` gains a `toXmlString(boolean prettyPrint)` method to expose this.

In investigating noted that the non-pretty printed code path for JSON generation was not actually exercised in tests so modified some existing JSON generator tests to verify that non-pretty printed output is smaller.

When modifying the equivalent XML generation tests found that the equivalent test case wasn't actually exercising XML generation at all so fixed that which exposed a bug in how the XML generator serialized properties which was leading to `JsonMappingException`'s from Jackson.  That bug is also fixed with this commit.