### PR TITLE
Bump CodeQL actions to 4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,10 +32,10 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # tag=v3.29.5
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # tag=v4.37.0
       with:
         languages: java
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # tag=v3.29.5
+      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # tag=v4.37.0
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # tag=v3.29.5
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # tag=v4.37.0


### PR DESCRIPTION
Also updates the `tag=...` annotation as Dependabot fails to do so on its own.

Closes https://github.com/CycloneDX/cyclonedx-core-java/pull/884
Closes https://github.com/CycloneDX/cyclonedx-core-java/pull/883
Closes https://github.com/CycloneDX/cyclonedx-core-java/pull/882 