### PR TITLE
Make XML parsing and validation resilient to outdated XML parsers on the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,16 @@
             <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- outdated XML parser on the test classpath: ensures XML BOM validation keeps working
+             even when a library leaks Xerces 2.x onto the classpath (regression for
+             https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/349) -->
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.12.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,9 @@
 
   Copyright (c) OWASP Foundation. All Rights Reserved.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -144,7 +146,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.20.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
@@ -202,8 +204,9 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- outdated XML parser on the test classpath: ensures XML BOM validation keeps working
-             even when a library leaks Xerces 2.x onto the classpath (regression for
+        <!-- outdated XML parser used by XercesFallbackTest, which forces it via the JAXP system
+             properties to verify that BOM parsing/validation stays functional and XXE-safe when
+             an old parser is chosen instead of the JDK's built-in one (regression for
              https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/349) -->
         <dependency>
             <groupId>xerces</groupId>

--- a/src/main/java/org/cyclonedx/CycloneDxSchema.java
+++ b/src/main/java/org/cyclonedx/CycloneDxSchema.java
@@ -30,6 +30,7 @@ import com.networknt.schema.keyword.NonValidationKeyword;
 import com.networknt.schema.serialization.DefaultNodeReader;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
+import org.cyclonedx.util.XmlFactoryUtils;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
@@ -331,9 +332,16 @@ public abstract class CycloneDxSchema
   }
 
   public Schema getXmlSchema(InputStream... inputStreams) throws SAXException {
-    final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-    schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-    schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    final SchemaFactory schemaFactory = XmlFactoryUtils.newSchemaFactory();
+    try {
+      schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (SAXException e) {
+      // JAXP 1.5 secure-processing properties are not supported by outdated SchemaFactory
+      // implementations (e.g. Xerces 2.x found on the classpath): restricting external access
+      // is a hardening measure and not required for correctness, as only local schema copies
+      // are used, so ignore and continue
+    }
     schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     final Source[] schemaFiles = new Source[inputStreams.length];
     for (int i = 0; i < inputStreams.length; i++) {

--- a/src/main/java/org/cyclonedx/CycloneDxSchema.java
+++ b/src/main/java/org/cyclonedx/CycloneDxSchema.java
@@ -338,9 +338,10 @@ public abstract class CycloneDxSchema
       schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
     } catch (SAXException e) {
       // JAXP 1.5 secure-processing properties are not supported by outdated SchemaFactory
-      // implementations (e.g. Xerces 2.x found on the classpath): restricting external access
-      // is a hardening measure and not required for correctness, as only local schema copies
-      // are used, so ignore and continue
+      // implementations (e.g. Xerces 2.x found on the classpath). Secure processing alone does
+      // not prevent XXE there, so compensate by disallowing DOCTYPE declarations entirely;
+      // if that is unsupported too, fail rather than validate insecurely
+      schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
     }
     schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     final Source[] schemaFiles = new Source[inputStreams.length];

--- a/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
+++ b/src/main/java/org/cyclonedx/generators/xml/BomXmlGenerator.java
@@ -35,6 +35,7 @@ import org.cyclonedx.generators.AbstractBomGenerator;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.util.XmlFactoryUtils;
 import org.cyclonedx.util.introspector.VersionXmlAnnotationIntrospector;
 import org.cyclonedx.util.serializer.DependencySerializer;
 import org.w3c.dom.Document;
@@ -84,7 +85,7 @@ public class BomXmlGenerator extends AbstractBomGenerator
      * @throws javax.xml.parsers.ParserConfigurationException thrown if there is a parser configuration exception
      */
     private DocumentBuilder buildSecureDocumentBuilder() throws ParserConfigurationException {
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilderFactory factory = XmlFactoryUtils.newDocumentBuilderFactory();
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/src/main/java/org/cyclonedx/parsers/XmlParser.java
+++ b/src/main/java/org/cyclonedx/parsers/XmlParser.java
@@ -39,6 +39,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
@@ -211,6 +212,17 @@ public class XmlParser extends CycloneDxSchema implements Parser {
         try {
             final Schema schema = getXmlSchema(schemaVersion);
             final Validator validator = schema.newValidator();
+            Source validationSource = source;
+            try {
+                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            } catch (SAXException e) {
+                // JAXP 1.5 secure-processing properties are not supported by outdated Validator
+                // implementations (e.g. Xerces 2.x found on the classpath), leaving the validator
+                // vulnerable to XXE. Compensate by parsing the input with the hardened (DOCTYPE
+                // rejecting) DocumentBuilder and validating the resulting DOM instead
+                validationSource = toSecureDomSource(source);
+            }
             validator.setErrorHandler(new ErrorHandler() {
                 @Override
                 public void warning(SAXParseException e) {
@@ -227,11 +239,23 @@ public class XmlParser extends CycloneDxSchema implements Parser {
                     exceptions.add(new ParseException(e.getMessage(), e));
                 }
             });
-            validator.validate(source);
-        } catch (SAXException e) {
+            validator.validate(validationSource);
+        } catch (SAXException | ParserConfigurationException e) {
             exceptions.add(new ParseException(e.getMessage(), e));
         }
         return exceptions;
+    }
+
+    private Source toSecureDomSource(final Source source) throws ParserConfigurationException, IOException, SAXException {
+        if (!(source instanceof StreamSource)) {
+            return source;
+        }
+        final StreamSource streamSource = (StreamSource) source;
+        final InputSource inputSource = new InputSource(streamSource.getSystemId());
+        inputSource.setByteStream(streamSource.getInputStream());
+        inputSource.setCharacterStream(streamSource.getReader());
+        // namespace awareness is required for schema validation of a DOM
+        return new DOMSource(createSecureDocument(inputSource, true));
     }
 
     /**
@@ -335,15 +359,24 @@ public class XmlParser extends CycloneDxSchema implements Parser {
 
     private Document createSecureDocument(InputSource in) throws ParserConfigurationException, IOException, SAXException
     {
+        return createSecureDocument(in, false);
+    }
+
+    private Document createSecureDocument(InputSource in, boolean namespaceAware) throws ParserConfigurationException, IOException, SAXException
+    {
         //https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xpathexpression
         DocumentBuilderFactory df = XmlFactoryUtils.newDocumentBuilderFactory();
+        df.setNamespaceAware(namespaceAware);
         try {
             df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         } catch (IllegalArgumentException e) {
             // JAXP 1.5 secure-processing attributes are not supported by outdated
-            // DocumentBuilderFactory implementations (e.g. Xerces 2.x found on the classpath):
-            // secure processing below still prevents external entity resolution, so ignore
+            // DocumentBuilderFactory implementations (e.g. Xerces 2.x found on the classpath).
+            // Secure processing alone does not prevent XXE there, so compensate by disallowing
+            // DOCTYPE declarations entirely; if that is unsupported too, fail rather than
+            // parse insecurely
+            df.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         }
         df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder builder = df.newDocumentBuilder();

--- a/src/main/java/org/cyclonedx/parsers/XmlParser.java
+++ b/src/main/java/org/cyclonedx/parsers/XmlParser.java
@@ -33,13 +33,15 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
@@ -219,9 +221,9 @@ public class XmlParser extends CycloneDxSchema implements Parser {
             } catch (SAXException e) {
                 // JAXP 1.5 secure-processing properties are not supported by outdated Validator
                 // implementations (e.g. Xerces 2.x found on the classpath), leaving the validator
-                // vulnerable to XXE. Compensate by parsing the input with the hardened (DOCTYPE
-                // rejecting) DocumentBuilder and validating the resulting DOM instead
-                validationSource = toSecureDomSource(source);
+                // vulnerable to XXE. Compensate by feeding the raw input through a hardened
+                // XMLReader, keeping validation streaming
+                validationSource = toSecureSaxSource(source);
             }
             validator.setErrorHandler(new ErrorHandler() {
                 @Override
@@ -246,16 +248,37 @@ public class XmlParser extends CycloneDxSchema implements Parser {
         return exceptions;
     }
 
-    private Source toSecureDomSource(final Source source) throws ParserConfigurationException, IOException, SAXException {
-        if (!(source instanceof StreamSource)) {
+    private Source toSecureSaxSource(final Source source) throws ParserConfigurationException, SAXException {
+        final InputSource inputSource;
+        if (source instanceof StreamSource) {
+            final StreamSource streamSource = (StreamSource) source;
+            inputSource = new InputSource(streamSource.getSystemId());
+            inputSource.setByteStream(streamSource.getInputStream());
+            inputSource.setCharacterStream(streamSource.getReader());
+        } else if (source instanceof SAXSource) {
+            inputSource = ((SAXSource) source).getInputSource();
+        } else {
+            // DOMSource/StAXSource carry pre-parsed content: the validator has no raw XML
+            // left to parse, so there is nothing to harden here
             return source;
         }
-        final StreamSource streamSource = (StreamSource) source;
-        final InputSource inputSource = new InputSource(streamSource.getSystemId());
-        inputSource.setByteStream(streamSource.getInputStream());
-        inputSource.setCharacterStream(streamSource.getReader());
-        // namespace awareness is required for schema validation of a DOM
-        return new DOMSource(createSecureDocument(inputSource, true));
+        return new SAXSource(createSecureXmlReader(), inputSource);
+    }
+
+    private XMLReader createSecureXmlReader() throws ParserConfigurationException, SAXException {
+        final SAXParserFactory factory = XmlFactoryUtils.newSAXParserFactory();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        final XMLReader reader = factory.newSAXParser().getXMLReader();
+        try {
+            reader.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            reader.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (SAXException e) {
+            // same compensation as in createSecureDocument: disallow DOCTYPE declarations
+            // entirely when the JAXP 1.5 properties are unsupported
+            reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        }
+        return reader;
     }
 
     /**
@@ -359,14 +382,8 @@ public class XmlParser extends CycloneDxSchema implements Parser {
 
     private Document createSecureDocument(InputSource in) throws ParserConfigurationException, IOException, SAXException
     {
-        return createSecureDocument(in, false);
-    }
-
-    private Document createSecureDocument(InputSource in, boolean namespaceAware) throws ParserConfigurationException, IOException, SAXException
-    {
         //https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xpathexpression
         DocumentBuilderFactory df = XmlFactoryUtils.newDocumentBuilderFactory();
-        df.setNamespaceAware(namespaceAware);
         try {
             df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");

--- a/src/main/java/org/cyclonedx/parsers/XmlParser.java
+++ b/src/main/java/org/cyclonedx/parsers/XmlParser.java
@@ -24,6 +24,7 @@ import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.util.XmlFactoryUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -335,9 +336,15 @@ public class XmlParser extends CycloneDxSchema implements Parser {
     private Document createSecureDocument(InputSource in) throws ParserConfigurationException, IOException, SAXException
     {
         //https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xpathexpression
-        DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
-        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        DocumentBuilderFactory df = XmlFactoryUtils.newDocumentBuilderFactory();
+        try {
+            df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException e) {
+            // JAXP 1.5 secure-processing attributes are not supported by outdated
+            // DocumentBuilderFactory implementations (e.g. Xerces 2.x found on the classpath):
+            // secure processing below still prevents external entity resolution, so ignore
+        }
         df.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder builder = df.newDocumentBuilder();
         return builder.parse(in);

--- a/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
+++ b/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.SchemaFactory;
+
+/**
+ * Creates JAXP factories for XML processing, preferring the JDK's built-in system-default
+ * implementations over the JAXP lookup mechanism.
+ *
+ * <p>The standard {@code newInstance()} lookup uses the classpath (ServiceLoader / system
+ * properties), so an outdated XML parser leaking onto the classpath (e.g. Xerces 2.x pulled in
+ * transitively by another library) would be picked up and break BOM parsing and validation with
+ * errors like {@code Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not
+ * recognized}, because such parsers pre-date the JAXP 1.5 secure-processing properties.
+ * See <a href="https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/349">cyclonedx-gradle-plugin#349</a>.</p>
+ *
+ * <p>The {@code newDefaultInstance()} factory methods only exist since Java 9 while this library
+ * targets Java 8, so they are invoked reflectively, falling back to the standard lookup.</p>
+ *
+ * @since 13.1.0
+ */
+public final class XmlFactoryUtils
+{
+    private XmlFactoryUtils() {
+    }
+
+    /**
+     * Creates a new {@link DocumentBuilderFactory}, preferring the JDK's built-in implementation.
+     *
+     * @return a new {@link DocumentBuilderFactory}
+     */
+    public static DocumentBuilderFactory newDocumentBuilderFactory() {
+        try {
+            return (DocumentBuilderFactory) DocumentBuilderFactory.class.getMethod("newDefaultInstance").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            return DocumentBuilderFactory.newInstance();
+        }
+    }
+
+    /**
+     * Creates a new {@link SchemaFactory} for W3C XML Schema, preferring the JDK's built-in
+     * implementation.
+     *
+     * @return a new {@link SchemaFactory}
+     */
+    public static SchemaFactory newSchemaFactory() {
+        try {
+            return (SchemaFactory) SchemaFactory.class.getMethod("newDefaultInstance").invoke(null);
+        } catch (ReflectiveOperationException e) {
+            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        }
+    }
+}

--- a/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
+++ b/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
@@ -33,6 +33,11 @@ import javax.xml.validation.SchemaFactory;
  * recognized}, because such parsers pre-date the JAXP 1.5 secure-processing properties.
  * See <a href="https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/349">cyclonedx-gradle-plugin#349</a>.</p>
  *
+ * <p>An implementation explicitly requested via the JAXP system properties
+ * ({@code javax.xml.parsers.DocumentBuilderFactory} /
+ * {@code javax.xml.validation.SchemaFactory:<schemaLanguage>}) is still honored, as that is a
+ * deliberate configuration choice rather than an accidental classpath leak.</p>
+ *
  * <p>The {@code newDefaultInstance()} factory methods only exist since Java 9 while this library
  * targets Java 8, so they are invoked reflectively, falling back to the standard lookup.</p>
  *
@@ -44,29 +49,38 @@ public final class XmlFactoryUtils
     }
 
     /**
-     * Creates a new {@link DocumentBuilderFactory}, preferring the JDK's built-in implementation.
+     * Creates a new {@link DocumentBuilderFactory}, preferring the JDK's built-in implementation
+     * unless one is explicitly requested via the {@code javax.xml.parsers.DocumentBuilderFactory}
+     * system property.
      *
      * @return a new {@link DocumentBuilderFactory}
      */
     public static DocumentBuilderFactory newDocumentBuilderFactory() {
-        try {
-            return (DocumentBuilderFactory) DocumentBuilderFactory.class.getMethod("newDefaultInstance").invoke(null);
-        } catch (ReflectiveOperationException e) {
-            return DocumentBuilderFactory.newInstance();
+        if (System.getProperty(DocumentBuilderFactory.class.getName()) == null) {
+            try {
+                return (DocumentBuilderFactory) DocumentBuilderFactory.class.getMethod("newDefaultInstance").invoke(null);
+            } catch (ReflectiveOperationException e) {
+                // Java 8: fall back to the standard lookup below
+            }
         }
+        return DocumentBuilderFactory.newInstance();
     }
 
     /**
      * Creates a new {@link SchemaFactory} for W3C XML Schema, preferring the JDK's built-in
-     * implementation.
+     * implementation unless one is explicitly requested via the
+     * {@code javax.xml.validation.SchemaFactory:http://www.w3.org/2001/XMLSchema} system property.
      *
      * @return a new {@link SchemaFactory}
      */
     public static SchemaFactory newSchemaFactory() {
-        try {
-            return (SchemaFactory) SchemaFactory.class.getMethod("newDefaultInstance").invoke(null);
-        } catch (ReflectiveOperationException e) {
-            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        if (System.getProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI) == null) {
+            try {
+                return (SchemaFactory) SchemaFactory.class.getMethod("newDefaultInstance").invoke(null);
+            } catch (ReflectiveOperationException e) {
+                // Java 8: fall back to the standard lookup below
+            }
         }
+        return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
     }
 }

--- a/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
+++ b/src/main/java/org/cyclonedx/util/XmlFactoryUtils.java
@@ -20,6 +20,7 @@ package org.cyclonedx.util;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.validation.SchemaFactory;
 
 /**
@@ -64,6 +65,24 @@ public final class XmlFactoryUtils
             }
         }
         return DocumentBuilderFactory.newInstance();
+    }
+
+    /**
+     * Creates a new {@link SAXParserFactory}, preferring the JDK's built-in implementation
+     * unless one is explicitly requested via the {@code javax.xml.parsers.SAXParserFactory}
+     * system property.
+     *
+     * @return a new {@link SAXParserFactory}
+     */
+    public static SAXParserFactory newSAXParserFactory() {
+        if (System.getProperty(SAXParserFactory.class.getName()) == null) {
+            try {
+                return (SAXParserFactory) SAXParserFactory.class.getMethod("newDefaultInstance").invoke(null);
+            } catch (ReflectiveOperationException e) {
+                // Java 8: fall back to the standard lookup below
+            }
+        }
+        return SAXParserFactory.newInstance();
     }
 
     /**

--- a/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
@@ -24,13 +24,9 @@ import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.util.XmlFactoryUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.util.SetSystemProperty;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.validation.SchemaFactory;
 import java.io.InputStream;
 import java.util.List;
 
@@ -46,29 +42,18 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * path (including the XXE compensations) on every JVM, Xerces is forced via the explicit JAXP
  * system properties, which {@link XmlFactoryUtils} deliberately honors.</p>
  */
+@SetSystemProperty(key = "javax.xml.parsers.DocumentBuilderFactory", value = "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl")
+@SetSystemProperty(key = "javax.xml.parsers.SAXParserFactory", value = "org.apache.xerces.jaxp.SAXParserFactoryImpl")
+@SetSystemProperty(key = "javax.xml.validation.SchemaFactory:http://www.w3.org/2001/XMLSchema", value = "org.apache.xerces.jaxp.validation.XMLSchemaFactory")
 class XercesFallbackTest {
-
-    private static final String DBF_PROPERTY = DocumentBuilderFactory.class.getName();
-
-    private static final String SF_PROPERTY = SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI;
-
-    @BeforeAll
-    static void forceXerces() {
-        System.setProperty(DBF_PROPERTY, "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
-        System.setProperty(SF_PROPERTY, "org.apache.xerces.jaxp.validation.XMLSchemaFactory");
-    }
-
-    @AfterAll
-    static void restoreDefaults() {
-        System.clearProperty(DBF_PROPERTY);
-        System.clearProperty(SF_PROPERTY);
-    }
 
     @Test
     void factoriesShouldBeXerces() {
         // guards the premise of this test class: Xerces is actually instantiated
         assertThat(XmlFactoryUtils.newDocumentBuilderFactory().getClass().getName())
                 .isEqualTo("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
+        assertThat(XmlFactoryUtils.newSAXParserFactory().getClass().getName())
+                .isEqualTo("org.apache.xerces.jaxp.SAXParserFactoryImpl");
         assertThat(XmlFactoryUtils.newSchemaFactory().getClass().getName())
                 .isEqualTo("org.apache.xerces.jaxp.validation.XMLSchemaFactory");
     }

--- a/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.parsers;
+
+import org.apache.commons.io.IOUtils;
+import org.cyclonedx.Version;
+import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.generators.BomGeneratorFactory;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.util.XmlFactoryUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.SchemaFactory;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Verifies that BOM parsing, validation, and generation remain functional and XXE-safe when an
+ * outdated XML parser (Xerces 2.x) is chosen instead of the JDK's built-in implementation.
+ *
+ * <p>CI runs on Java 9+ where {@link XmlFactoryUtils} always prefers the JDK factories over the
+ * classpath lookup, so a leaked Xerces would never be instantiated. To exercise the Xerces code
+ * path (including the XXE compensations) on every JVM, Xerces is forced via the explicit JAXP
+ * system properties, which {@link XmlFactoryUtils} deliberately honors.</p>
+ */
+class XercesFallbackTest {
+
+    private static final String DBF_PROPERTY = DocumentBuilderFactory.class.getName();
+
+    private static final String SF_PROPERTY = SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI;
+
+    @BeforeAll
+    static void forceXerces() {
+        System.setProperty(DBF_PROPERTY, "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
+        System.setProperty(SF_PROPERTY, "org.apache.xerces.jaxp.validation.XMLSchemaFactory");
+    }
+
+    @AfterAll
+    static void restoreDefaults() {
+        System.clearProperty(DBF_PROPERTY);
+        System.clearProperty(SF_PROPERTY);
+    }
+
+    @Test
+    void factoriesShouldBeXerces() {
+        // guards the premise of this test class: Xerces is actually instantiated
+        assertThat(XmlFactoryUtils.newDocumentBuilderFactory().getClass().getName())
+                .isEqualTo("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
+        assertThat(XmlFactoryUtils.newSchemaFactory().getClass().getName())
+                .isEqualTo("org.apache.xerces.jaxp.validation.XMLSchemaFactory");
+    }
+
+    @Test
+    void parseShouldWorkWithXerces() throws Exception {
+        final Bom bom = new XmlParser().parse(resource("/bom-1.5.xml"));
+        assertThat(bom.getSpecVersion()).isEqualTo("1.5");
+        assertThat(bom.getComponents()).isNotEmpty();
+    }
+
+    @Test
+    void validateShouldWorkWithXerces() throws Exception {
+        final List<ParseException> validationFailures =
+                new XmlParser().validate(resource("/bom-1.5.xml"), Version.VERSION_15);
+        assertThat(validationFailures).isEmpty();
+    }
+
+    @Test
+    void generateShouldWorkWithXerces() throws Exception {
+        final Bom bom = new XmlParser().parse(resource("/bom-1.5.xml"));
+        final org.w3c.dom.Document document =
+                BomGeneratorFactory.createXml(Version.VERSION_15, bom).generate();
+        assertThat(document).isNotNull();
+    }
+
+    @Test
+    void parseShouldNotBeVulnerableToXxeWithXerces() throws Exception {
+        final byte[] bomBytes = resource("/security/xxe-protection.xml");
+        // the doctype must be rejected before any external entity can be resolved
+        assertThatExceptionOfType(ParseException.class)
+                .isThrownBy(() -> new XmlParser().parse(bomBytes))
+                .withMessageContaining("DOCTYPE");
+    }
+
+    @Test
+    void validateShouldNotBeVulnerableToXxeWithXerces() throws Exception {
+        final List<ParseException> validationFailures =
+                new XmlParser().validate(resource("/security/xxe-protection.xml"));
+        assertThat(validationFailures).isNotEmpty();
+        assertThat(validationFailures).extracting(Throwable::getMessage).allSatisfy(
+                failureMessage -> assertThat(failureMessage).contains("DOCTYPE"));
+    }
+
+    private static byte[] resource(final String name) throws Exception {
+        try (final InputStream inputStream = XercesFallbackTest.class.getResourceAsStream(name)) {
+            assertThat(inputStream).isNotNull();
+            return IOUtils.toByteArray(inputStream);
+        }
+    }
+}


### PR DESCRIPTION
Related to CycloneDX/cyclonedx-gradle-plugin#349

## Problem

When an outdated XML parser such as Xerces 2.x leaks onto the classpath (pulled in transitively by another library or Gradle plugin), the JAXP lookup mechanism (`SchemaFactory.newInstance` / `DocumentBuilderFactory.newInstance`) picks it up, and BOM parsing/validation fails hard:

```
SAXNotRecognizedException: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.
```

These parsers pre-date the JAXP 1.5 secure-processing properties. This is what breaks `cyclonedxBom` in CycloneDX/cyclonedx-gradle-plugin#349 whenever any other plugin ships Xerces on the buildscript classpath - reproducible with a plain Gradle 8.4 project, the current gradle plugin 3.3.0, and `xerces:xercesImpl:2.12.2` added to the buildscript classpath.

## Fix

- new `XmlFactoryUtils` prefers the JDK's built-in `SchemaFactory` / `DocumentBuilderFactory` via `newDefaultInstance()`, bypassing the classpath-based JAXP lookup. An implementation explicitly requested via the JAXP system properties is still honored - only the accidental classpath/ServiceLoader leak is bypassed. `newDefaultInstance()` only exists since Java 9 while this library targets Java 8, so it is invoked reflectively with a fallback to the standard lookup
- used in the three affected sites: `CycloneDxSchema.getXmlSchema`, `XmlParser.createSecureDocument`, `BomXmlGenerator.buildSecureDocumentBuilder`

### XXE compensations when an outdated parser is chosen (review feedback)

Secure processing alone does not prevent XXE in Xerces 2.x, so when the JAXP 1.5 `ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` properties are unsupported the code now compensates instead of continuing insecurely:

- `CycloneDxSchema.getXmlSchema` and `XmlParser.createSecureDocument` set `http://apache.org/xml/features/disallow-doctype-decl` as a fallback; if that is unsupported too, the exception propagates (fail-secure)
- Xerces accepts `disallow-doctype-decl` on `XMLSchemaFactory` but does **not** propagate it to `Validator` instances (`XMLSchemaValidatorComponentManager` hardcodes it to `false`), leaving validation of untrusted input XXE-vulnerable. `XmlParser.validate` therefore probes the `Validator` for the JAXP 1.5 properties and, when unsupported, wraps the input in a `SAXSource` backed by a hardened `XMLReader` - validation stays fully streaming, and `SAXSource` inputs are re-wrapped the same way (`DOMSource`/`StAXSource` carry pre-parsed content and pass through)

## Regression coverage

CI runs on Java 17/21/25 where `newDefaultInstance()` always succeeds, so a leaked Xerces would never be instantiated by the tests. The new `XercesFallbackTest` forces real Xerces 2.12.2 factories via the explicit JAXP system properties (guarded by an assertion that the factories actually are Xerces) and verifies on every CI JVM:

- parse, validate, and generate of a valid BOM keep working
- the XXE payload (`security/xxe-protection.xml`) is rejected with `DOCTYPE is disallowed` on both the parse and the validate path

## Verification

- `mvn clean verify` green (1620 tests, 0 failures)
- reproducer for the gradle plugin scenario: Gradle 8.4 + plugin 3.3.0 + `xercesImpl` on the buildscript classpath fails with `Error whilst validating XML BOM` / `SAXNotRecognizedException` today; with this fix in core-java, validation uses the JDK parser and is unaffected
