### PR TITLE
Drop dependencies on Apache Commons libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,29 +128,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Apache Commons -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.22.1</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.22.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.20.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.5.0</version>
-        </dependency>
-
         <!-- Package URL -->
 
         <dependency>

--- a/src/main/java/org/cyclonedx/parsers/BomParserFactory.java
+++ b/src/main/java/org/cyclonedx/parsers/BomParserFactory.java
@@ -18,7 +18,6 @@
  */
 package org.cyclonedx.parsers;
 
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.exception.ParseException;
 
 import java.io.File;
@@ -35,7 +34,14 @@ public class BomParserFactory {
     public static Parser createParser(final File file) throws ParseException {
         try (final InputStream fis = Files.newInputStream(file.toPath())) {
             final byte[] prefix = new byte[4]; // potential 3-byte UTF-8 byte-order mark + 1 content byte
-            final int actualPrefixLength = IOUtils.read(fis, prefix);
+            int actualPrefixLength = 0;
+            while (actualPrefixLength < prefix.length) {
+                final int read = fis.read(prefix, actualPrefixLength, prefix.length - actualPrefixLength);
+                if (read == -1) {
+                    break;
+                }
+                actualPrefixLength += read;
+            }
             return createParser(Arrays.copyOf(prefix, actualPrefixLength));
         } catch (IOException e) {
             throw new ParseException("An error occurred creating parser from file", e);

--- a/src/main/java/org/cyclonedx/parsers/JsonParser.java
+++ b/src/main/java/org/cyclonedx/parsers/JsonParser.java
@@ -21,8 +21,6 @@ package org.cyclonedx.parsers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.Error;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.Format;
 import org.cyclonedx.Version;
@@ -32,8 +30,8 @@ import org.cyclonedx.model.Bom;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -106,7 +104,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final File file, final Version schemaVersion) throws IOException {
-        return validate(FileUtils.readFileToString(file, StandardCharsets.UTF_8), schemaVersion);
+        return validate(mapper.readTree(file), schemaVersion);
     }
 
     /**
@@ -120,7 +118,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final byte[] bomBytes, final Version schemaVersion) throws IOException {
-        return validate(new String(bomBytes), schemaVersion);
+        return validate(mapper.readTree(bomBytes), schemaVersion);
     }
 
     /**
@@ -134,7 +132,14 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final Reader reader, final Version schemaVersion) throws IOException {
-        return validate(IOUtils.toString(reader), schemaVersion);
+        // NB: Jackson does not strip a UTF-8 BOM from char-based input, but it DOES do that
+        // for byte-based input, hence the manual handling here.
+        final PushbackReader pushbackReader = new PushbackReader(reader);
+        final int firstChar = pushbackReader.read();
+        if (firstChar != -1 && firstChar != '\uFEFF') {
+            pushbackReader.unread(firstChar);
+        }
+        return validate(mapper.readTree(pushbackReader), schemaVersion);
     }
 
     /**
@@ -148,7 +153,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final InputStream inputStream, final Version schemaVersion) throws IOException {
-        return validate(IOUtils.toString(inputStream, StandardCharsets.UTF_8), schemaVersion);
+        return validate(mapper.readTree(inputStream), schemaVersion);
     }
 
     /**

--- a/src/main/java/org/cyclonedx/util/BomUtils.java
+++ b/src/main/java/org/cyclonedx/util/BomUtils.java
@@ -18,8 +18,6 @@
  */
 package org.cyclonedx.util;
 
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.VersionFilter;
@@ -109,7 +107,7 @@ public final class BomUtils {
                 digests.stream().parallel().forEach(d -> d.update(buf, 0, read));
             }
         }
-        digests.stream().map(d -> new Hash(toAlgorithm(d), Hex.encodeHexString(d.digest()))).forEach(hashes::add);
+        digests.stream().map(d -> new Hash(toAlgorithm(d), toHexString(d.digest()))).forEach(hashes::add);
         return hashes;
     }
 
@@ -133,27 +131,6 @@ public final class BomUtils {
     private static MessageDigest getDigestForAlgorithm(Hash.Algorithm algorithm) {
         try {
             switch (algorithm) {
-                case MD5:
-                    return DigestUtils.getMd5Digest();
-                case SHA1:
-                    return DigestUtils.getSha1Digest();
-                case SHA_256:
-                    return DigestUtils.getSha256Digest();
-                case SHA_384:
-                    return DigestUtils.getSha384Digest();
-                case SHA_512:
-                    return DigestUtils.getSha512Digest();
-                case SHA3_256:
-                    return DigestUtils.getSha3_256Digest();
-                case SHA3_384:
-                    return DigestUtils.getSha3_384Digest();
-                case SHA3_512:
-                    return DigestUtils.getSha3_512Digest();
-                case BLAKE2b_256:
-                case BLAKE2b_384:
-                case BLAKE2b_512:
-                case BLAKE3:
-                    return MessageDigest.getInstance(algorithm.getSpec());
                 case STREEBOG_256:
                     // NB: Requires a 3rd party library such as BouncyCastle.
                     return MessageDigest.getInstance("GOST3411-2012-256");
@@ -161,11 +138,21 @@ public final class BomUtils {
                     // NB: Requires a 3rd party library such as BouncyCastle.
                     return MessageDigest.getInstance("GOST3411-2012-512");
                 default:
-                    throw new IllegalArgumentException("Unsupported algorithm: " + algorithm.getSpec());
+                    // BLAKE2b and BLAKE3 also require a 3rd party library such as BouncyCastle.
+                    return MessageDigest.getInstance(algorithm.getSpec());
             }
-        } catch (NoSuchAlgorithmException | NoSuchMethodError e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException("Algorithm not available: " + algorithm.getSpec(), e);
         }
+    }
+
+    private static String toHexString(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte b : bytes) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+            sb.append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
     }
 
     private static Hash.Algorithm toAlgorithm(MessageDigest digest) {

--- a/src/main/java/org/cyclonedx/util/LicenseResolver.java
+++ b/src/main/java/org/cyclonedx/util/LicenseResolver.java
@@ -19,16 +19,14 @@
 package org.cyclonedx.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.IOUtils;
+import org.cyclonedx.model.AttachmentText;
 import org.cyclonedx.model.License;
 import org.cyclonedx.model.LicenseChoice;
-import org.cyclonedx.model.AttachmentText;
 import org.cyclonedx.model.license.Expression;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -112,7 +110,7 @@ public final class LicenseResolver {
           licenses = mapper.readValue(is, LicenseList.class);        
         }
 
-        if (licenses != null && CollectionUtils.isNotEmpty(licenses.licenses)) {
+        if (licenses != null && (licenses.licenses != null && !licenses.licenses.isEmpty())) {
             for (LicenseDetail licenseDetail : licenses.licenses) {
 
                 final String primaryLicenseUrl = (licenseDetail.seeAlso != null && !licenseDetail.seeAlso.isEmpty()) ? licenseDetail.seeAlso.get(0) : null;
@@ -163,7 +161,7 @@ public final class LicenseResolver {
 
         if (mappings != null) {
             for (final SpdxLicenseMapping licenseMapping : mappings) {
-                if (CollectionUtils.isNotEmpty(licenseMapping.names)) {
+                if (licenseMapping.names != null && !licenseMapping.names.isEmpty()) {
                     for (final String name : licenseMapping.names) {
                         if (licenseString.equalsIgnoreCase(name)) {
                             if (licenseMapping.exp.startsWith("(") && licenseMapping.exp.endsWith(")")) {
@@ -197,19 +195,18 @@ public final class LicenseResolver {
         license.setId(licenseId);
         license.setUrl(primaryLicenseUrl);
         if (!isDeprecatedLicenseId && licenseTextSettings.isTextIncluded()) {
-            final InputStream is = LicenseResolver.class.getResourceAsStream("/licenses/" + licenseId + ".txt");
-            if (is != null) {
-                final String text = IOUtils.toString(is, StandardCharsets.UTF_8);
+            final byte[] text = readLicenseText(licenseId);
+            if (text != null) {
                 final AttachmentText attachment = new AttachmentText();
                 attachment.setContentType("text/plain");
                 switch(licenseTextSettings.getEncoding()){
                     case NONE:
                         attachment.setEncoding(null);
-                        attachment.setText(text);
+                        attachment.setText(new String(text, StandardCharsets.UTF_8));
                         break;
                     case BASE64:
                         attachment.setEncoding(licenseTextSettings.getEncoding().toString());
-                        attachment.setText(Base64.getEncoder().encodeToString(text.getBytes(Charset.defaultCharset())));
+                        attachment.setText(Base64.getEncoder().encodeToString(text));
                         break;
                     default:
                         throw new IllegalArgumentException("Unhandled License Encoding:" + licenseTextSettings.getEncoding().toString() );
@@ -264,6 +261,22 @@ public final class LicenseResolver {
         }
         public void setEncoding(LicenseEncoding encoding) {
             this.encoding = encoding;
+        }
+    }
+
+    private static byte[] readLicenseText(final String licenseId) throws IOException {
+        try (final InputStream is = LicenseResolver.class.getResourceAsStream("/licenses/" + licenseId + ".txt")) {
+            if (is == null) {
+                return null;
+            }
+
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final byte[] buf = new byte[8192];
+            int n;
+            while ((n = is.read(buf)) != -1) {
+                out.write(buf, 0, n);
+            }
+            return out.toByteArray();
         }
     }
 

--- a/src/main/java/org/cyclonedx/util/ObjectLocator.java
+++ b/src/main/java/org/cyclonedx/util/ObjectLocator.java
@@ -18,7 +18,6 @@
  */
 package org.cyclonedx.util;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Service;
@@ -103,7 +102,7 @@ public class ObjectLocator {
         for (final Component component: components) {
             if (bomRef.equals(component.getBomRef())) {
                 return component;
-            } else if (CollectionUtils.isNotEmpty(component.getComponents())) {
+            } else if (component.getComponents() != null && !component.getComponents().isEmpty()) {
                 final Component child = findComponent(component.getComponents(), bomRef);
                 if (child != null) return child;
             }
@@ -116,7 +115,7 @@ public class ObjectLocator {
         for (final Service service: services) {
             if (bomRef.equals(service.getBomRef())) {
                 return service;
-            } else if (CollectionUtils.isNotEmpty(service.getServices())) {
+            } else if (service.getServices() != null && !service.getServices().isEmpty()) {
                 final Service child = findService(service.getServices(), bomRef);
                 if (child != null) return child;
             }

--- a/src/main/java/org/cyclonedx/util/deserializer/ExtensionDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/ExtensionDeserializer.java
@@ -18,20 +18,12 @@
  */
 package org.cyclonedx.util.deserializer;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.cyclonedx.model.ExtensibleType;
 import org.cyclonedx.model.Extension;
 import org.cyclonedx.model.Extension.ExtensionType;
@@ -43,6 +35,13 @@ import org.cyclonedx.model.vulnerability.Vulnerability10.Recommendation;
 import org.cyclonedx.model.vulnerability.Vulnerability10.Score;
 import org.cyclonedx.model.vulnerability.Vulnerability10.ScoreSource;
 import org.cyclonedx.model.vulnerability.Vulnerability10.Severity;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 public class ExtensionDeserializer extends StdDeserializer<Extension>
 {
@@ -183,8 +182,10 @@ public class ExtensionDeserializer extends StdDeserializer<Extension>
 
   private Cwe processCwe(final JsonNode cwe) {
     Cwe c = new Cwe();
-    if (NumberUtils.isParsable(cwe.textValue())) {
+    try {
       c.setText(Integer.valueOf(cwe.textValue()));
+    } catch (NumberFormatException e) {
+      // Not a CWE ID; leave unset.
     }
     return c;
   }

--- a/src/main/java/org/cyclonedx/util/deserializer/VulnerabilityDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/VulnerabilityDeserializer.java
@@ -18,10 +18,6 @@
  */
 package org.cyclonedx.util.deserializer;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -29,13 +25,16 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.model.OrganizationalContact;
 import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.vulnerability.Vulnerability;
 import org.cyclonedx.util.TimestampUtils;
 import org.cyclonedx.util.ToolsJsonParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class VulnerabilityDeserializer
@@ -72,42 +71,42 @@ public class VulnerabilityDeserializer
 
     if (node.has("bom-ref")) {
       String bomRef = node.get("bom-ref").asText();
-      if (StringUtils.isNotEmpty(bomRef)) {
+      if (bomRef != null && !bomRef.isEmpty()) {
         vulnerability.setBomRef(bomRef);
       }
     }
 
     if (node.has("id")) {
       String id = node.get("id").asText();
-      if (StringUtils.isNotEmpty(id)) {
+      if (id != null && !id.isEmpty()) {
         vulnerability.setId(id);
       }
     }
 
     if (node.has("description")) {
       String description = node.get("description").asText();
-      if (StringUtils.isNotEmpty(description)) {
+      if (description != null && !description.isEmpty()) {
         vulnerability.setDescription(description);
       }
     }
 
     if (node.has("detail")) {
       String detail = node.get("detail").asText();
-      if (StringUtils.isNotEmpty(detail)) {
+      if (detail != null && !detail.isEmpty()) {
         vulnerability.setDetail(detail);
       }
     }
 
     if (node.has("recommendation")) {
       String recommendation = node.get("recommendation").asText();
-      if (StringUtils.isNotEmpty(recommendation)) {
+      if (recommendation != null && !recommendation.isEmpty()) {
         vulnerability.setRecommendation(recommendation);
       }
     }
 
     if (node.has("workaround")) {
       String workaround = node.get("workaround").asText();
-      if (StringUtils.isNotEmpty(workaround)) {
+      if (workaround != null && !workaround.isEmpty()) {
         vulnerability.setWorkaround(workaround);
       }
     }
@@ -247,7 +246,7 @@ public class VulnerabilityDeserializer
       }
       if (analysisNode.has("detail")) {
         String detail = analysisNode.get("detail").asText();
-        if (StringUtils.isNotEmpty(detail)) {
+        if (detail != null && !detail.isEmpty()) {
           analysis.setDetail(detail);
         }
       }

--- a/src/main/java/org/cyclonedx/util/serializer/DependencySerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/DependencySerializer.java
@@ -18,24 +18,21 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.util.List;
-
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.ser.ContextualSerializer;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.DependencyList;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.util.List;
 
 public class DependencySerializer extends StdSerializer<DependencyList> implements ContextualSerializer
 {
@@ -71,7 +68,7 @@ public class DependencySerializer extends StdSerializer<DependencyList> implemen
       throws IOException
   {
     try {
-      if ((generator instanceof ToXmlGenerator)) {
+      if (generator instanceof ToXmlGenerator) {
         writeXMLDependenciesWithGenerator((ToXmlGenerator) generator,
             dependencies);
       }
@@ -91,7 +88,7 @@ public class DependencySerializer extends StdSerializer<DependencyList> implemen
           generator.writeStartObject();
           generator.writeStringField(REF, dependency.getRef());
           generator.writeArrayFieldStart("dependsOn");
-          if (CollectionUtils.isNotEmpty(dependency.getDependencies())) {
+          if (dependency.getDependencies() != null && !dependency.getDependencies().isEmpty()) {
             for (Dependency subDependency : dependency.getDependencies()) {
               generator.writeString(subDependency.getRef());
             }
@@ -125,7 +122,7 @@ public class DependencySerializer extends StdSerializer<DependencyList> implemen
   {
     processNamespace(generator, "dependency");
 
-    if (CollectionUtils.isNotEmpty(dependency.getDependencies())) {
+    if (dependency.getDependencies() != null && !dependency.getDependencies().isEmpty()) {
       generator.writeStartArray();
     }
 
@@ -134,14 +131,14 @@ public class DependencySerializer extends StdSerializer<DependencyList> implemen
     generator.writeString(dependency.getRef());
     generator.setNextIsAttribute(false);
 
-    if (CollectionUtils.isNotEmpty(dependency.getDependencies())) {
+    if (dependency.getDependencies() != null && !dependency.getDependencies().isEmpty()) {
       for (Dependency subDependency : dependency.getDependencies()) {
         // You got Shay'd
         writeXMLDependency(subDependency, generator);
       }
     }
 
-    if (CollectionUtils.isNotEmpty(dependency.getDependencies())) {
+    if (dependency.getDependencies() != null && !dependency.getDependencies().isEmpty()) {
     generator.writeEndArray();
   }
 
@@ -153,7 +150,7 @@ public class DependencySerializer extends StdSerializer<DependencyList> implemen
   {
     QName qName;
 
-    String dependenciesNamespace = StringUtils.isBlank(dependencies) ? "dependencies" : dependencies;
+    String dependenciesNamespace = (dependencies == null || dependencies.trim().isEmpty()) ? "dependencies" : dependencies;
 
     if (useNamespace) {
       qName = new QName(CycloneDxSchema.NS_DEPENDENCY_GRAPH_10, dependenciesNamespace, "dg");

--- a/src/main/java/org/cyclonedx/util/serializer/EvidenceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/EvidenceSerializer.java
@@ -1,17 +1,16 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Copyright;
 import org.cyclonedx.model.Evidence;
 import org.cyclonedx.model.component.evidence.Identity;
 import org.cyclonedx.model.component.evidence.Occurrence;
+
+import java.io.IOException;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -45,7 +44,7 @@ public class EvidenceSerializer
 
   private void serializeXml(final ToXmlGenerator xmlGenerator, final Evidence evidence, SerializerProvider serializerProvider) throws IOException {
     xmlGenerator.writeStartObject();
-    if (CollectionUtils.isNotEmpty(evidence.getIdentities()) && shouldSerializeField(evidence, version, "identities")) {
+    if ((evidence.getIdentities() != null && !evidence.getIdentities().isEmpty()) && shouldSerializeField(evidence, version, "identities")) {
       if (version.getVersion() >= Version.VERSION_16.getVersion()) {
         xmlGenerator.writeFieldName("identity");
         xmlGenerator.writeStartArray();
@@ -59,7 +58,7 @@ public class EvidenceSerializer
       }
     }
 
-    if (CollectionUtils.isNotEmpty(evidence.getOccurrences()) && shouldSerializeField(evidence, version, "occurrences")) {
+    if ((evidence.getOccurrences() != null && !evidence.getOccurrences().isEmpty()) && shouldSerializeField(evidence, version, "occurrences")) {
       xmlGenerator.writeFieldName("occurrences");
       xmlGenerator.writeStartObject(); // Start the occurrences object
       for (Occurrence occurrence : evidence.getOccurrences()) {
@@ -71,7 +70,7 @@ public class EvidenceSerializer
 
     serializeCommonInfo(xmlGenerator, evidence, serializerProvider);
 
-    if (CollectionUtils.isNotEmpty(evidence.getCopyright()) && shouldSerializeField(evidence, version, "copyright")) {
+    if ((evidence.getCopyright() != null && !evidence.getCopyright().isEmpty()) && shouldSerializeField(evidence, version, "copyright")) {
       xmlGenerator.writeFieldName("copyright");
       xmlGenerator.writeStartObject();
       for (Copyright item : evidence.getCopyright()) {
@@ -84,7 +83,7 @@ public class EvidenceSerializer
 
   private void serializeJson(final JsonGenerator gen, final Evidence evidence, SerializerProvider serializerProvider) throws IOException {
     gen.writeStartObject();
-    if (CollectionUtils.isNotEmpty(evidence.getIdentities()) && shouldSerializeField(evidence, version, "identities")) {
+    if ((evidence.getIdentities() != null && !evidence.getIdentities().isEmpty()) && shouldSerializeField(evidence, version, "identities")) {
       if (version.getVersion() >= Version.VERSION_16.getVersion()) {
         gen.writeObjectField("identity", evidence.getIdentities());
       }
@@ -93,13 +92,13 @@ public class EvidenceSerializer
       }
     }
 
-    if (CollectionUtils.isNotEmpty(evidence.getOccurrences()) && shouldSerializeField(evidence, version, "occurrences")) {
+    if ((evidence.getOccurrences() != null && !evidence.getOccurrences().isEmpty()) && shouldSerializeField(evidence, version, "occurrences")) {
       gen.writeObjectField("occurrences", evidence.getOccurrences());
     }
 
     serializeCommonInfo(gen, evidence, serializerProvider);
 
-    if (CollectionUtils.isNotEmpty(evidence.getCopyright()) && shouldSerializeField(evidence, version, "copyright")) {
+    if ((evidence.getCopyright() != null && !evidence.getCopyright().isEmpty()) && shouldSerializeField(evidence, version, "copyright")) {
       gen.writeFieldName("copyright");
       gen.writeStartArray();
       for (Copyright item : evidence.getCopyright()) {

--- a/src/main/java/org/cyclonedx/util/serializer/ExtensibleTypesSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/ExtensibleTypesSerializer.java
@@ -18,19 +18,17 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.util.List;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.model.Attribute;
 import org.cyclonedx.model.ExtensibleType;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.util.List;
 
 public class ExtensibleTypesSerializer extends StdSerializer<List<ExtensibleType>>
 {
@@ -53,9 +51,9 @@ public class ExtensibleTypesSerializer extends StdSerializer<List<ExtensibleType
     final ToXmlGenerator toXmlGenerator = (ToXmlGenerator) generator;
     final XMLStreamWriter staxWriter = toXmlGenerator.getStaxWriter();
     try {
-      if (CollectionUtils.isNotEmpty(extensibleTypes)) {
+      if (extensibleTypes != null && !extensibleTypes.isEmpty()) {
         for (ExtensibleType ext : extensibleTypes) {
-          if (CollectionUtils.isNotEmpty(ext.getAttributes())) {
+          if (ext.getAttributes() != null && !ext.getAttributes().isEmpty()) {
             Attribute xmlNS = ext.getAttributes().stream()
                 .filter(a -> a.getKey().contains(XMLNS))
                 .findAny()
@@ -72,7 +70,7 @@ public class ExtensibleTypesSerializer extends StdSerializer<List<ExtensibleType
             staxWriter.writeStartElement(ext.getNamespace(), ext.getName(), "http://www.w3.org/1999/xhtml");
           }
 
-          if (CollectionUtils.isNotEmpty(ext.getExtensibleTypes())) {
+          if (ext.getExtensibleTypes() != null && !ext.getExtensibleTypes().isEmpty()) {
             serialize(ext.getExtensibleTypes(), generator, provider);
           }
           if (ext.getValue() != null) {

--- a/src/main/java/org/cyclonedx/util/serializer/ExtensionSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/ExtensionSerializer.java
@@ -18,16 +18,10 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.model.ExtensibleType;
 import org.cyclonedx.model.Extension;
 import org.cyclonedx.model.Extension.ExtensionType;
@@ -36,6 +30,10 @@ import org.cyclonedx.model.vulnerability.Vulnerability10;
 import org.cyclonedx.model.vulnerability.Vulnerability10.Advisory;
 import org.cyclonedx.model.vulnerability.Vulnerability10.Cwe;
 import org.cyclonedx.model.vulnerability.Vulnerability10.Recommendation;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
 
 public class ExtensionSerializer
     extends StdSerializer<Extension>
@@ -92,7 +90,7 @@ public class ExtensionSerializer
   private void processAdvisories(final XMLStreamWriter staxWriter, final Vulnerability10 vuln)
       throws XMLStreamException
   {
-    if (CollectionUtils.isNotEmpty(vuln.getAdvisories())) {
+    if (vuln.getAdvisories() != null && !vuln.getAdvisories().isEmpty()) {
       staxWriter.writeStartElement(Vulnerability10.PREFIX, Vulnerability10.ADVISORIES, Vulnerability10.NAMESPACE_URI);
       for (Advisory a : vuln.getAdvisories()) {
         generateTextNode(staxWriter, Vulnerability10.ADVISORY, a.getText(), Vulnerability10.NAMESPACE_URI, Vulnerability10.PREFIX);
@@ -104,7 +102,7 @@ public class ExtensionSerializer
   private void processRecommendations(final XMLStreamWriter staxWriter, final Vulnerability10 vuln)
       throws XMLStreamException
   {
-    if (CollectionUtils.isNotEmpty(vuln.getRecommendations())) {
+    if (vuln.getRecommendations() != null && !vuln.getRecommendations().isEmpty()) {
       staxWriter.writeStartElement(Vulnerability10.PREFIX, Vulnerability10.RECOMMENDATIONS, Vulnerability10.NAMESPACE_URI);
       for (Recommendation r : vuln.getRecommendations()) {
         generateTextNode(staxWriter, Vulnerability10.RECOMMENDATION, r.getText(), Vulnerability10.NAMESPACE_URI, Vulnerability10.PREFIX);
@@ -116,7 +114,7 @@ public class ExtensionSerializer
   private void processCwes(final XMLStreamWriter staxWriter, final Vulnerability10 vuln)
       throws XMLStreamException
   {
-    if (CollectionUtils.isNotEmpty(vuln.getCwes())) {
+    if (vuln.getCwes() != null && !vuln.getCwes().isEmpty()) {
       staxWriter.writeStartElement(Vulnerability10.PREFIX, Vulnerability10.CWES, Vulnerability10.NAMESPACE_URI);
       for (Cwe c : vuln.getCwes()) {
         generateTextNodeFromNumber(staxWriter, Vulnerability10.CWE, c.getText(), Vulnerability10.NAMESPACE_URI, Vulnerability10.PREFIX);
@@ -142,7 +140,7 @@ public class ExtensionSerializer
   private void processRatings(final XMLStreamWriter staxWriter, final Vulnerability10 vuln)
       throws XMLStreamException
   {
-    if (CollectionUtils.isNotEmpty(vuln.getRatings())) {
+    if (vuln.getRatings() != null && !vuln.getRatings().isEmpty()) {
       staxWriter.writeStartElement(Vulnerability10.PREFIX, Vulnerability10.RATINGS, Vulnerability10.NAMESPACE_URI);
       for (Rating r : vuln.getRatings()) {
         staxWriter.writeStartElement(Vulnerability10.PREFIX, Vulnerability10.RATING, Vulnerability10.NAMESPACE_URI);

--- a/src/main/java/org/cyclonedx/util/serializer/ExternalReferenceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/ExternalReferenceSerializer.java
@@ -18,20 +18,19 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.function.BiPredicate;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.ExternalReference.Type;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.util.BomUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiPredicate;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.serializeHashJson;
 
@@ -86,7 +85,7 @@ public class ExternalReferenceSerializer
     }
 
     List<Hash> hashes = SerializerUtils.filterHashesByVersion(extRef.getHashes(), version);
-    if (CollectionUtils.isNotEmpty(hashes)) {
+    if (hashes != null && !hashes.isEmpty()) {
       toXmlGenerator.writeFieldName("hashes");
       toXmlGenerator.writeStartObject();
       for (Hash hash : hashes) {
@@ -107,7 +106,7 @@ public class ExternalReferenceSerializer
     }
 
     List<Hash> hashes = SerializerUtils.filterHashesByVersion(extRef.getHashes(), version);
-    if (CollectionUtils.isNotEmpty(hashes)) {
+    if (hashes != null && !hashes.isEmpty()) {
       gen.writeFieldName("hashes");
       gen.writeStartArray();
       for (Hash hash : hashes) {

--- a/src/main/java/org/cyclonedx/util/serializer/InputTypeSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/InputTypeSerializer.java
@@ -1,14 +1,13 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.formulation.common.InputType;
+
+import java.io.IOException;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -49,7 +48,7 @@ public class InputTypeSerializer
       jsonGenerator.writeFieldName("resource");
       jsonGenerator.writeObject(input.getResource());
     }
-    else if (CollectionUtils.isNotEmpty(input.getParameters()) && shouldSerializeField(input, version, "parameters")) {
+    else if ((input.getParameters() != null && !input.getParameters().isEmpty()) && shouldSerializeField(input, version, "parameters")) {
       jsonGenerator.writeFieldName("parameters");
       jsonGenerator.writeObject(input.getParameters());
     }

--- a/src/main/java/org/cyclonedx/util/serializer/LicenseChoiceSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/LicenseChoiceSerializer.java
@@ -18,14 +18,10 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.License;
 import org.cyclonedx.model.LicenseChoice;
@@ -33,8 +29,10 @@ import org.cyclonedx.model.LicenseItem;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.license.Acknowledgement;
 import org.cyclonedx.model.license.Expression;
-import org.cyclonedx.model.license.ExpressionDetailed;
 import org.cyclonedx.model.license.ExpressionDetail;
+import org.cyclonedx.model.license.ExpressionDetailed;
+
+import java.io.IOException;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -102,10 +100,10 @@ public class LicenseChoiceSerializer
     toXmlGenerator.writeStartObject();
     serializeXmlAttributes(toXmlGenerator, l.getBomRef(), l.getAcknowledgement(), l);
 
-    if (StringUtils.isNotBlank(l.getId())) {
+    if (l.getId() != null && !l.getId().trim().isEmpty()) {
       toXmlGenerator.writeStringField("id", l.getId());
     }
-    else if (StringUtils.isNotBlank(l.getName())) {
+    else if (l.getName() != null && !l.getName().trim().isEmpty()) {
       toXmlGenerator.writeStringField("name", l.getName());
     }
 
@@ -117,11 +115,11 @@ public class LicenseChoiceSerializer
       toXmlGenerator.writeObjectField("text", l.getAttachmentText());
     }
 
-    if (StringUtils.isNotBlank(l.getUrl())) {
+    if (l.getUrl() != null && !l.getUrl().trim().isEmpty()) {
       toXmlGenerator.writeStringField("url", l.getUrl());
     }
 
-    if (CollectionUtils.isNotEmpty(l.getProperties()) && shouldSerializeField(l, version, "properties")) {
+    if ((l.getProperties() != null && !l.getProperties().isEmpty()) && shouldSerializeField(l, version, "properties")) {
       toXmlGenerator.writeFieldName("properties");
       toXmlGenerator.writeStartObject();
 
@@ -132,7 +130,7 @@ public class LicenseChoiceSerializer
     }
 
     //It might have extensible types
-    if(CollectionUtils.isNotEmpty(l.getExtensibleTypes())) {
+    if (l.getExtensibleTypes() != null && !l.getExtensibleTypes().isEmpty()) {
       new ExtensibleTypesSerializer().serialize(l.getExtensibleTypes(), toXmlGenerator, provider);
     }
 
@@ -145,7 +143,7 @@ public class LicenseChoiceSerializer
       final Acknowledgement acknowledgement,
       final Object object) throws IOException
   {
-    if (StringUtils.isNotBlank(bomRef) && shouldSerializeField(object, version, "bomRef")) {
+    if ((bomRef != null && !bomRef.trim().isEmpty()) && shouldSerializeField(object, version, "bomRef")) {
       toXmlGenerator.setNextIsAttribute(true);
       toXmlGenerator.writeFieldName("bom-ref");
       toXmlGenerator.writeString(bomRef);
@@ -204,7 +202,7 @@ public class LicenseChoiceSerializer
     toXmlGenerator.writeStartObject();
 
     // Write expression as an attribute (required)
-    if (StringUtils.isNotBlank(expressionDetailed.getExpression())) {
+    if (expressionDetailed.getExpression() != null && !expressionDetailed.getExpression().trim().isEmpty()) {
       toXmlGenerator.setNextIsAttribute(true);
       toXmlGenerator.writeFieldName("expression");
       toXmlGenerator.writeString(expressionDetailed.getExpression());
@@ -214,7 +212,7 @@ public class LicenseChoiceSerializer
     // Write other attributes (bom-ref, acknowledgement)
     serializeXmlAttributes(toXmlGenerator, expressionDetailed.getBomRef(), expressionDetailed.getAcknowledgement(), expressionDetailed);
 
-    if (CollectionUtils.isNotEmpty(expressionDetailed.getExpressionDetails())) {
+    if (expressionDetailed.getExpressionDetails() != null && !expressionDetailed.getExpressionDetails().isEmpty()) {
       for (ExpressionDetail detail : expressionDetailed.getExpressionDetails()) {
         toXmlGenerator.writeObjectField("details", detail);
       }
@@ -224,7 +222,7 @@ public class LicenseChoiceSerializer
       toXmlGenerator.writeObjectField("licensing", expressionDetailed.getLicensing());
     }
 
-    if (CollectionUtils.isNotEmpty(expressionDetailed.getProperties()) && shouldSerializeField(expressionDetailed, version, "properties")) {
+    if ((expressionDetailed.getProperties() != null && !expressionDetailed.getProperties().isEmpty()) && shouldSerializeField(expressionDetailed, version, "properties")) {
       toXmlGenerator.writeFieldName("properties");
       toXmlGenerator.writeStartObject();
       for (Property property : expressionDetailed.getProperties()) {
@@ -242,7 +240,7 @@ public class LicenseChoiceSerializer
     if (expression.getAcknowledgement() != null && shouldSerializeField(expression, version, "acknowledgement")) {
       gen.writeStringField("acknowledgement", expression.getAcknowledgement().getValue());
     }
-    if (StringUtils.isNotBlank(expression.getBomRef()) && shouldSerializeField(expression, version, "bomRef")) {
+    if ((expression.getBomRef() != null && !expression.getBomRef().trim().isEmpty()) && shouldSerializeField(expression, version, "bomRef")) {
       gen.writeStringField("bom-ref", expression.getBomRef());
     }
   }
@@ -251,22 +249,22 @@ public class LicenseChoiceSerializer
       final ExpressionDetailed expressionDetailed, final JsonGenerator gen, final SerializerProvider provider)
       throws IOException {
     // Flatten the expressionDetailed fields into the license item object
-    if (StringUtils.isNotBlank(expressionDetailed.getBomRef())) {
+    if (expressionDetailed.getBomRef() != null && !expressionDetailed.getBomRef().trim().isEmpty()) {
       gen.writeStringField("bom-ref", expressionDetailed.getBomRef());
     }
     if (expressionDetailed.getAcknowledgement() != null) {
       gen.writeObjectField("acknowledgement", expressionDetailed.getAcknowledgement());
     }
-    if (StringUtils.isNotBlank(expressionDetailed.getExpression())) {
+    if (expressionDetailed.getExpression() != null && !expressionDetailed.getExpression().trim().isEmpty()) {
       gen.writeStringField("expression", expressionDetailed.getExpression());
     }
-    if (CollectionUtils.isNotEmpty(expressionDetailed.getExpressionDetails())) {
+    if (expressionDetailed.getExpressionDetails() != null && !expressionDetailed.getExpressionDetails().isEmpty()) {
       gen.writeObjectField("expressionDetails", expressionDetailed.getExpressionDetails());
     }
     if (expressionDetailed.getLicensing() != null) {
       gen.writeObjectField("licensing", expressionDetailed.getLicensing());
     }
-    if (CollectionUtils.isNotEmpty(expressionDetailed.getProperties())) {
+    if (expressionDetailed.getProperties() != null && !expressionDetailed.getProperties().isEmpty()) {
       gen.writeObjectField("properties", expressionDetailed.getProperties());
     }
   }

--- a/src/main/java/org/cyclonedx/util/serializer/MetadataSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/MetadataSerializer.java
@@ -1,17 +1,16 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.metadata.ToolInformation;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -66,7 +65,7 @@ public class MetadataSerializer
     //Tools
     parseTools(metadata, jsonGenerator);
 
-    if (CollectionUtils.isNotEmpty(metadata.getAuthors()) && shouldSerializeField(metadata, version, "author")) {
+    if ((metadata.getAuthors() != null && !metadata.getAuthors().isEmpty()) && shouldSerializeField(metadata, version, "author")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(metadata.getAuthors(), xmlGenerator, "author");
@@ -97,7 +96,7 @@ public class MetadataSerializer
       new LicenseChoiceSerializer(isXml, version).serialize(metadata.getLicenses(), jsonGenerator, serializerProvider);
     }
 
-    if (CollectionUtils.isNotEmpty(metadata.getProperties()) && shouldSerializeField(metadata, version, "properties")) {
+    if ((metadata.getProperties() != null && !metadata.getProperties().isEmpty()) && shouldSerializeField(metadata, version, "properties")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         xmlGenerator.writeFieldName("properties");
@@ -131,18 +130,18 @@ public class MetadataSerializer
         jsonGenerator.writeFieldName("tools");
         jsonGenerator.writeStartObject();
         if (isXml && jsonGenerator instanceof ToXmlGenerator) {
-          if (CollectionUtils.isNotEmpty(choice.getComponents())) {
+          if (choice.getComponents() != null && !choice.getComponents().isEmpty()) {
             writeArrayFieldXML(choice.getComponents(), (ToXmlGenerator) jsonGenerator, "component");
           }
-          if (CollectionUtils.isNotEmpty(choice.getServices())) {
+          if (choice.getServices() != null && !choice.getServices().isEmpty()) {
             writeArrayFieldXML(choice.getServices(), (ToXmlGenerator) jsonGenerator, "service");
           }
         }
         else {
-          if (CollectionUtils.isNotEmpty(choice.getComponents())) {
+          if (choice.getComponents() != null && !choice.getComponents().isEmpty()) {
             writeArrayFieldJSON(jsonGenerator, "components", choice.getComponents());
           }
-          if (CollectionUtils.isNotEmpty(choice.getServices())) {
+          if (choice.getServices() != null && !choice.getServices().isEmpty()) {
             writeArrayFieldJSON(jsonGenerator, "services", choice.getServices());
           }
         }
@@ -164,7 +163,7 @@ public class MetadataSerializer
   }
 
   private <T> void writeArrayFieldXML(List<T> items, ToXmlGenerator xmlGenerator, String fieldName) throws IOException {
-    if (CollectionUtils.isNotEmpty(items)) {
+    if (items != null && !items.isEmpty()) {
       xmlGenerator.writeFieldName(fieldName + "s");
       xmlGenerator.writeStartObject();
       for (T item : items) {

--- a/src/main/java/org/cyclonedx/util/serializer/OutputTypeSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/OutputTypeSerializer.java
@@ -1,14 +1,13 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.formulation.common.OutputType;
+
+import java.io.IOException;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -101,7 +100,7 @@ public class OutputTypeSerializer
       xmlGenerator.writeFieldName("target");
       xmlGenerator.writeObject(output.getTarget());
     }
-    if (CollectionUtils.isNotEmpty(output.getProperties()) && shouldSerializeField(output, version, "properties")) {
+    if ((output.getProperties() != null && !output.getProperties().isEmpty()) && shouldSerializeField(output, version, "properties")) {
       xmlGenerator.writeFieldName("properties");
       xmlGenerator.writeObject(output.getProperties());
     }

--- a/src/main/java/org/cyclonedx/util/serializer/PropertiesSerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/PropertiesSerializer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.model.Property;
 
 import java.io.IOException;
@@ -27,7 +26,7 @@ public class PropertiesSerializer
   public void serialize(List<Property> properties, JsonGenerator jsonGenerator, SerializerProvider serializers)
       throws IOException
   {
-    if (CollectionUtils.isEmpty(properties)) {
+    if (properties == null || properties.isEmpty()) {
       return; // Do not serialize if the list is null or empty
     }
 

--- a/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
+++ b/src/main/java/org/cyclonedx/util/serializer/SerializerUtils.java
@@ -1,21 +1,20 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.Hash.Algorithm;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.VersionFilter;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SerializerUtils
 {
@@ -142,7 +141,7 @@ public class SerializerUtils
   }
 
   public static void serializeProperty(String propertyName,  Property prop, ToXmlGenerator xmlGenerator) throws IOException {
-    if (StringUtils.isNotBlank(propertyName)) {
+    if (propertyName != null && !propertyName.trim().isEmpty()) {
       xmlGenerator.writeFieldName(propertyName);
     }
     xmlGenerator.writeStartObject();

--- a/src/main/java/org/cyclonedx/util/serializer/SignatorySerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/SignatorySerializer.java
@@ -1,14 +1,12 @@
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.model.attestation.affirmation.Signatory;
+
+import java.io.IOException;
 
 public class SignatorySerializer
     extends StdSerializer<Signatory>
@@ -39,14 +37,14 @@ public class SignatorySerializer
       throws IOException
   {
     //It might have extensible types (signature)
-    if (CollectionUtils.isNotEmpty(signatory.getExtensibleTypes())) {
+    if (signatory.getExtensibleTypes() != null && !signatory.getExtensibleTypes().isEmpty()) {
       gen.writeStartObject();
 
-      if (StringUtils.isNotBlank(signatory.getName())) {
+      if (signatory.getName() != null && !signatory.getName().trim().isEmpty()) {
         gen.writeStringField("name", signatory.getName());
       }
 
-      if (StringUtils.isNotBlank(signatory.getRole())) {
+      if (signatory.getRole() != null && !signatory.getRole().trim().isEmpty()) {
         gen.writeStringField("role", signatory.getRole());
       }
 
@@ -70,11 +68,11 @@ public class SignatorySerializer
     if (shouldSerialize) {
       gen.writeStartObject();
 
-      if (StringUtils.isNotBlank(signatory.getName())) {
+      if (signatory.getName() != null && !signatory.getName().trim().isEmpty()) {
         gen.writeStringField("name", signatory.getName());
       }
 
-      if (StringUtils.isNotBlank(signatory.getRole())) {
+      if (signatory.getRole() != null && !signatory.getRole().trim().isEmpty()) {
         gen.writeStringField("role", signatory.getRole());
       }
 

--- a/src/main/java/org/cyclonedx/util/serializer/VulnerabilitySerializer.java
+++ b/src/main/java/org/cyclonedx/util/serializer/VulnerabilitySerializer.java
@@ -18,22 +18,17 @@
  */
 package org.cyclonedx.util.serializer;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.Version;
-import org.cyclonedx.model.Component;
-import org.cyclonedx.model.Tool;
-import org.cyclonedx.model.vulnerability.Vulnerability;
-import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.model.Property;
+import org.cyclonedx.model.metadata.ToolInformation;
+import org.cyclonedx.model.vulnerability.Vulnerability;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.cyclonedx.util.serializer.SerializerUtils.shouldSerializeField;
 
@@ -75,7 +70,7 @@ public class VulnerabilitySerializer
   {
     jsonGenerator.writeStartObject();
 
-    if (StringUtils.isNotEmpty(vulnerability.getBomRef()) && shouldSerializeField(vulnerability, version, "bom-ref")) {
+    if ((vulnerability.getBomRef() != null && !vulnerability.getBomRef().isEmpty()) && shouldSerializeField(vulnerability, version, "bom-ref")) {
       if (isXml && jsonGenerator instanceof ToXmlGenerator) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         xmlGenerator.setNextIsAttribute(true);
@@ -86,7 +81,7 @@ public class VulnerabilitySerializer
       }
     }
 
-    if (StringUtils.isNotEmpty(vulnerability.getId()) && shouldSerializeField(vulnerability, version, "id")) {
+    if ((vulnerability.getId() != null && !vulnerability.getId().isEmpty()) && shouldSerializeField(vulnerability, version, "id")) {
       jsonGenerator.writeStringField("id", vulnerability.getId());
     }
 
@@ -94,7 +89,7 @@ public class VulnerabilitySerializer
       jsonGenerator.writeObjectField("source", vulnerability.getSource());
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getReferences()) && shouldSerializeField(vulnerability, version, "references")) {
+    if ((vulnerability.getReferences() != null && !vulnerability.getReferences().isEmpty()) && shouldSerializeField(vulnerability, version, "references")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(vulnerability.getReferences(), xmlGenerator, "reference");
@@ -104,7 +99,7 @@ public class VulnerabilitySerializer
       }
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getRatings()) && shouldSerializeField(vulnerability, version, "ratings")) {
+    if ((vulnerability.getRatings() != null && !vulnerability.getRatings().isEmpty()) && shouldSerializeField(vulnerability, version, "ratings")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(vulnerability.getRatings(), xmlGenerator, "rating");
@@ -114,7 +109,7 @@ public class VulnerabilitySerializer
       }
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getCwes()) && shouldSerializeField(vulnerability, version, "cwes")) {
+    if ((vulnerability.getCwes() != null && !vulnerability.getCwes().isEmpty()) && shouldSerializeField(vulnerability, version, "cwes")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(vulnerability.getCwes(), xmlGenerator, "cwe");
@@ -124,19 +119,19 @@ public class VulnerabilitySerializer
       }
     }
 
-    if (StringUtils.isNotEmpty(vulnerability.getDescription()) && shouldSerializeField(vulnerability, version, "description")) {
+    if ((vulnerability.getDescription() != null && !vulnerability.getDescription().isEmpty()) && shouldSerializeField(vulnerability, version, "description")) {
       jsonGenerator.writeStringField("description", vulnerability.getDescription());
     }
 
-    if (StringUtils.isNotEmpty(vulnerability.getDetail()) && shouldSerializeField(vulnerability, version, "detail")) {
+    if ((vulnerability.getDetail() != null && !vulnerability.getDetail().isEmpty()) && shouldSerializeField(vulnerability, version, "detail")) {
       jsonGenerator.writeStringField("detail", vulnerability.getDetail());
     }
 
-    if (StringUtils.isNotEmpty(vulnerability.getRecommendation()) && shouldSerializeField(vulnerability, version, "recommendation")) {
+    if ((vulnerability.getRecommendation() != null && !vulnerability.getRecommendation().isEmpty()) && shouldSerializeField(vulnerability, version, "recommendation")) {
       jsonGenerator.writeStringField("recommendation", vulnerability.getRecommendation());
     }
 
-    if (StringUtils.isNotEmpty(vulnerability.getWorkaround()) && shouldSerializeField(vulnerability, version, "workaround")) {
+    if ((vulnerability.getWorkaround() != null && !vulnerability.getWorkaround().isEmpty()) && shouldSerializeField(vulnerability, version, "workaround")) {
       jsonGenerator.writeStringField("workaround", vulnerability.getWorkaround());
     }
 
@@ -144,7 +139,7 @@ public class VulnerabilitySerializer
       jsonGenerator.writeObjectField("proofOfConcept", vulnerability.getProofOfConcept());
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getAdvisories()) && shouldSerializeField(vulnerability, version, "advisories")) {
+    if ((vulnerability.getAdvisories() != null && !vulnerability.getAdvisories().isEmpty()) && shouldSerializeField(vulnerability, version, "advisories")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(vulnerability.getAdvisories(), xmlGenerator, "advisories", "advisory");
@@ -185,7 +180,7 @@ public class VulnerabilitySerializer
       jsonGenerator.writeObjectField("analysis", vulnerability.getAnalysis());
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getAffects()) && shouldSerializeField(vulnerability, version, "affects")) {
+    if ((vulnerability.getAffects() != null && !vulnerability.getAffects().isEmpty()) && shouldSerializeField(vulnerability, version, "affects")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         writeArrayFieldXML(vulnerability.getAffects(), xmlGenerator, "affects", "target");
@@ -195,7 +190,7 @@ public class VulnerabilitySerializer
       }
     }
 
-    if (CollectionUtils.isNotEmpty(vulnerability.getProperties()) && shouldSerializeField(vulnerability, version, "properties")) {
+    if ((vulnerability.getProperties() != null && !vulnerability.getProperties().isEmpty()) && shouldSerializeField(vulnerability, version, "properties")) {
       if (isXml) {
         ToXmlGenerator xmlGenerator = (ToXmlGenerator) jsonGenerator;
         xmlGenerator.writeFieldName("properties");
@@ -218,23 +213,23 @@ public class VulnerabilitySerializer
     // For v1.5+, check if we have the new ToolInformation format first (priority over deprecated)
     if (version.getVersion() >= Version.VERSION_15.getVersion()) {
       ToolInformation choice = vulnerability.getToolChoice();
-      if (choice != null && (CollectionUtils.isNotEmpty(choice.getComponents()) || CollectionUtils.isNotEmpty(choice.getServices()))) {
+      if (choice != null && ((choice.getComponents() != null && !choice.getComponents().isEmpty()) || (choice.getServices() != null && !choice.getServices().isEmpty()))) {
         // Use the new format
         jsonGenerator.writeFieldName("tools");
         jsonGenerator.writeStartObject();
         if (isXml && jsonGenerator instanceof ToXmlGenerator) {
-          if (CollectionUtils.isNotEmpty(choice.getComponents())) {
+          if (choice.getComponents() != null && !choice.getComponents().isEmpty()) {
             writeArrayFieldXML(choice.getComponents(), (ToXmlGenerator) jsonGenerator, "component");
           }
-          if (CollectionUtils.isNotEmpty(choice.getServices())) {
+          if (choice.getServices() != null && !choice.getServices().isEmpty()) {
             writeArrayFieldXML(choice.getServices(), (ToXmlGenerator) jsonGenerator, "service");
           }
         }
         else {
-          if (CollectionUtils.isNotEmpty(choice.getComponents())) {
+          if (choice.getComponents() != null && !choice.getComponents().isEmpty()) {
             writeArrayFieldJSON(jsonGenerator, "components", choice.getComponents());
           }
-          if (CollectionUtils.isNotEmpty(choice.getServices())) {
+          if (choice.getServices() != null && !choice.getServices().isEmpty()) {
             writeArrayFieldJSON(jsonGenerator, "services", choice.getServices());
           }
         }
@@ -244,7 +239,7 @@ public class VulnerabilitySerializer
     }
 
     // Fall back to deprecated tools format if present
-    if (CollectionUtils.isNotEmpty(vulnerability.getTools())) {
+    if (vulnerability.getTools() != null && !vulnerability.getTools().isEmpty()) {
       if (isXml && jsonGenerator instanceof ToXmlGenerator) {
         writeArrayFieldXML(vulnerability.getTools(), (ToXmlGenerator) jsonGenerator, "tool");
       }
@@ -271,7 +266,7 @@ public class VulnerabilitySerializer
   }
 
   private <T> void writeArrayFieldXML(List<T> items, ToXmlGenerator xmlGenerator, String wrapperName, String elementName) throws IOException {
-    if (CollectionUtils.isNotEmpty(items)) {
+    if (items != null && !items.isEmpty()) {
       xmlGenerator.writeFieldName(wrapperName);
       xmlGenerator.writeStartObject();
       for (T item : items) {

--- a/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomJsonGeneratorTest.java
@@ -19,9 +19,6 @@
 package org.cyclonedx;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
@@ -45,13 +42,19 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.stream.Stream;
 import java.util.Objects;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BomJsonGeneratorTest {
 
@@ -105,8 +108,7 @@ public class BomJsonGeneratorTest {
 
     @Test
     public void schema12MultipleDependenciesJsonTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.2.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.2.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -131,8 +133,7 @@ public class BomJsonGeneratorTest {
 
     @Test
     public void schema13MultipleDependenciesJsonTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.3.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.3.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -177,8 +178,7 @@ public class BomJsonGeneratorTest {
 
     @Test
     public void schema14MultipleDependenciesJsonTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.4.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.4.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -1048,14 +1048,14 @@ public class BomJsonGeneratorTest {
 
     private Bom createCommonXmlBom(String resource) throws Exception {
         final byte[] bomBytes =
-            IOUtils.toByteArray(Objects.requireNonNull(this.getClass().getResourceAsStream(resource)));
+            Objects.requireNonNull(this.getClass().getResourceAsStream(resource)).readAllBytes();
         XmlParser parser = new XmlParser();
         return parser.parse(bomBytes);
     }
 
     private Bom createCommonJsonBom(String resource) throws Exception {
         final byte[] bomBytes =
-            IOUtils.toByteArray(Objects.requireNonNull(this.getClass().getResourceAsStream(resource)));
+            Objects.requireNonNull(this.getClass().getResourceAsStream(resource)).readAllBytes();
         JsonParser parser = new JsonParser();
         return parser.parse(bomBytes);
     }

--- a/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
+++ b/src/test/java/org/cyclonedx/BomXmlGeneratorTest.java
@@ -18,10 +18,8 @@
  */
 package org.cyclonedx;
 
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
-import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.cyclonedx.model.Attribute;
 import org.cyclonedx.model.Bom;
@@ -156,8 +154,7 @@ public class BomXmlGeneratorTest {
 
     @Test
     public void schema12MultipleDependenciesXmlTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.2.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.2.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -214,8 +211,7 @@ public class BomXmlGeneratorTest {
 
     @Test
     public void schema13MultipleDependenciesXmlTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.3.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.3.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -228,8 +224,7 @@ public class BomXmlGeneratorTest {
 
     @Test
     public void schema14MultipleDependenciesXmlTest() throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.4.json")));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream("/bom-1.4.json")).readAllBytes();
         final JsonParser parser = new JsonParser();
         final Bom bom = parser.parse(bomBytes);
 
@@ -1236,15 +1231,14 @@ public class BomXmlGeneratorTest {
     }
 
     private Bom createCommonBomXml(String resource) throws Exception {
-        final byte[] bomBytes = IOUtils.toByteArray(
-            Objects.requireNonNull(this.getClass().getResourceAsStream(resource)));
+        final byte[] bomBytes = Objects.requireNonNull(this.getClass().getResourceAsStream(resource)).readAllBytes();
         XmlParser parser = new XmlParser();
         return parser.parse(bomBytes);
     }
 
     private Bom createCommonJsonBom(String resource) throws Exception {
         final byte[] bomBytes =
-            IOUtils.toByteArray(Objects.requireNonNull(this.getClass().getResourceAsStream(resource)));
+            Objects.requireNonNull(this.getClass().getResourceAsStream(resource)).readAllBytes();
         JsonParser parser = new JsonParser();
         return parser.parse(bomBytes);
     }

--- a/src/test/java/org/cyclonedx/Issue214RegressionTest.java
+++ b/src/test/java/org/cyclonedx/Issue214RegressionTest.java
@@ -1,17 +1,7 @@
 package org.cyclonedx;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-
-import org.apache.commons.io.IOUtils;
-import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.exception.GeneratorException;
+import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.cyclonedx.model.Bom;
@@ -25,6 +15,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 
 public class Issue214RegressionTest
@@ -78,7 +77,7 @@ public class Issue214RegressionTest
     {
         try (InputStream is = getClass().getResourceAsStream(pPath)) {
             if (is != null) {
-                String result = IOUtils.toString(is, StandardCharsets.UTF_8);
+                String result = new String(is.readAllBytes(), StandardCharsets.UTF_8);
                 result = result.replaceAll(Pattern.quote("${specVersion}"), pSpecVersion.getVersionString());
                 return result;
             }

--- a/src/test/java/org/cyclonedx/parsers/AbstractParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/AbstractParserTest.java
@@ -18,14 +18,6 @@
  */
 package org.cyclonedx.parsers;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Annotation;
@@ -78,6 +70,12 @@ import org.cyclonedx.model.vulnerability.Vulnerability.Analysis.State;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating.Severity;
 import org.cyclonedx.model.vulnerability.Vulnerability.Version.Status;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -334,7 +332,7 @@ public class AbstractParserTest
       assertNull(inputType.getData());
       assertNull(inputType.getEnvironmentVars());
     }
-    else if (CollectionUtils.isNotEmpty(inputType.getParameters())) {
+    else if (inputType.getParameters() != null && !inputType.getParameters().isEmpty()) {
       assertNull(inputType.getResource());
       assertNull(inputType.getData());
       assertNull(inputType.getEnvironmentVars());
@@ -427,7 +425,7 @@ public class AbstractParserTest
   }
 
   private void assertProperties(List<Property> properties) {
-    if (CollectionUtils.isNotEmpty(properties)) {
+    if (properties != null && !properties.isEmpty()) {
       Property property = properties.get(0);
       assertNotNull(property.getName());
       assertNotNull(property.getValue());
@@ -1029,6 +1027,6 @@ public class AbstractParserTest
 
   private byte[] getBomBytes(String filename) throws IOException {
     final InputStream inputStream = this.getClass().getResourceAsStream("/" + filename);
-    return IOUtils.toByteArray(Objects.requireNonNull(inputStream));
+    return Objects.requireNonNull(inputStream).readAllBytes();
   }
 }

--- a/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XercesFallbackTest.java
@@ -18,7 +18,6 @@
  */
 package org.cyclonedx.parsers;
 
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
@@ -101,7 +100,7 @@ class XercesFallbackTest {
     private static byte[] resource(final String name) throws Exception {
         try (final InputStream inputStream = XercesFallbackTest.class.getResourceAsStream(name)) {
             assertThat(inputStream).isNotNull();
-            return IOUtils.toByteArray(inputStream);
+            return inputStream.readAllBytes();
         }
     }
 }

--- a/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/XmlParserTest.java
@@ -18,7 +18,6 @@
  */
 package org.cyclonedx.parsers;
 
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
@@ -1202,7 +1201,7 @@ public class XmlParserTest
         final byte[] bomBytes;
         try (final InputStream bomInputStream = getClass().getResourceAsStream("/security/xxe-protection.xml")) {
             assertThat(bomInputStream).isNotNull();
-            bomBytes = IOUtils.toByteArray(bomInputStream);
+            bomBytes = bomInputStream.readAllBytes();
         }
 
         final List<ParseException> validationFailures = new XmlParser().validate(bomBytes);

--- a/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
+++ b/src/test/java/org/cyclonedx/schema/BaseSchemaVerificationTest.java
@@ -18,11 +18,12 @@
  */
 package org.cyclonedx.schema;
 
-import org.apache.commons.io.IOUtils;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.Version;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,9 @@ public abstract class BaseSchemaVerificationTest {
         }
         try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(dir)) {
             if (in != null) {
-                files.addAll(IOUtils.readLines(in, StandardCharsets.UTF_8));
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                    reader.lines().forEach(files::add);
+                }
             }
         }
         return files;

--- a/src/test/java/org/cyclonedx/util/BomUtilsTest.java
+++ b/src/test/java/org/cyclonedx/util/BomUtilsTest.java
@@ -18,18 +18,18 @@
  */
 package org.cyclonedx.util;
 
-import org.apache.commons.io.FileUtils;
 import org.cyclonedx.Version;
 import org.cyclonedx.model.Hash;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.commons.io.FileUtils.ONE_KB;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cyclonedx.model.Hash.Algorithm.MD5;
 import static org.cyclonedx.model.Hash.Algorithm.SHA1;
@@ -41,6 +41,8 @@ import static org.cyclonedx.model.Hash.Algorithm.SHA_384;
 import static org.cyclonedx.model.Hash.Algorithm.SHA_512;
 
 public class BomUtilsTest {
+
+    private static final int ONE_KB = 1024;
 
     @Test
     public void calculateHashes() throws Exception {
@@ -105,11 +107,11 @@ public class BomUtilsTest {
         if (file.exists() && file.isFile() && file.length() == 10 * ONE_KB * ONE_KB) {
             return file;
         }
-        FileUtils.deleteQuietly(file);
+        Files.deleteIfExists(file.toPath());
         final byte[] partial = new byte[(int) ONE_KB];
         for (int i = 0; i < 10 * ONE_KB; i++) {
             Arrays.fill(partial, (byte)i);
-            FileUtils.writeByteArrayToFile(file, partial, true);
+            Files.write(file.toPath(), partial, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         }
         return file;
     }

--- a/src/test/java/org/cyclonedx/util/ObjectLocatorTest.java
+++ b/src/test/java/org/cyclonedx/util/ObjectLocatorTest.java
@@ -27,7 +27,6 @@ import org.cyclonedx.parsers.Parser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ObjectLocatorTest {
@@ -36,7 +35,7 @@ class ObjectLocatorTest {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        final byte[] bomBytes = resourceToByteArray("/bom-object-locator.json");
+        final byte[] bomBytes = ObjectLocatorTest.class.getResourceAsStream("/bom-object-locator.json").readAllBytes();
         final Parser parser = BomParserFactory.createParser(bomBytes);
         bom = parser.parse(bomBytes);
     }


### PR DESCRIPTION
They were only needed for minor convenience `isEmpty` / `isNotEmpty` style methods. All use cases for them are trivially achievable by means of the stdlib and don't justify the larger dependency footprint.