### PR TITLE
Fix JSON validation messages not containing instance locations

### DIFF
--- a/src/main/java/org/cyclonedx/parsers/JsonParser.java
+++ b/src/main/java/org/cyclonedx/parsers/JsonParser.java
@@ -187,8 +187,15 @@ public class JsonParser extends CycloneDxSchema implements Parser {
         }
 
         List<Error> errors = getJsonSchema(schemaVersion, mapper).validate(mapper.readTree(bomJson.toString()));
-        for (Error message: errors) {
-            exceptions.add(new ParseException(message.getMessage()));
+        for (Error error : errors) {
+            final boolean hasLocation =
+                    error.getInstanceLocation() != null
+                            && error.getInstanceLocation().getNameCount() > 0;
+            exceptions.add(
+                    new ParseException(
+                            hasLocation
+                                    ? error.getInstanceLocation() + ": " + error.getMessage()
+                                    : error.getMessage()));
         }
 
         return exceptions;

--- a/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
@@ -19,6 +19,7 @@
 package org.cyclonedx.parsers;
 
 import org.cyclonedx.Version;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Citation;
 import org.cyclonedx.model.Component;
@@ -97,6 +98,27 @@ public class JsonParserTest
         Bom bom = parser.parse(file);
         assertTrue(parser.isValid(file, Version.VERSION_12));
         System.out.println(bom.getSerialNumber());
+    }
+
+    @Test
+    public void testValidationErrorsIncludeInstanceLocation() throws Exception {
+        final String bomJson = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "components": [
+                    {
+                      "type": "no-such-type",
+                      "name": "acme-lib"
+                    }
+                  ]
+                }
+                """;
+        final List<ParseException> exceptions =
+                new JsonParser().validate(bomJson, Version.VERSION_16);
+        assertThat(exceptions)
+                .isNotEmpty()
+                .anySatisfy(e -> assertThat(e.getMessage()).startsWith("/components/0/type: "));
     }
 
     @Test


### PR DESCRIPTION
Validation errors are close to useless without knowing WHERE in the input document they occurred.

Regression of the `json-schema-validator` update to 2.x.