### PR TITLE
Fix missing slf4j implementation in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.18</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- outdated XML parser used by XercesFallbackTest, which forces it via the JAXP system
              properties to verify that BOM parsing/validation stays functional and XXE-safe when
              an old parser is chosen instead of the JDK's built-in one (regression for

--- a/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
+++ b/src/test/java/org/cyclonedx/parsers/JsonParserTest.java
@@ -96,7 +96,6 @@ public class JsonParserTest
         final JsonParser parser = new JsonParser();
         Bom bom = parser.parse(file);
         assertTrue(parser.isValid(file, Version.VERSION_12));
-        System.out.println(bom.getSerialNumber());
     }
 
     @Test

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=WARN


### PR DESCRIPTION
Some dependencies use the slf4j API for logging, but no slf4j implementation was on the classpath, leading to repeated warnings in test logs.