### PR TITLE
Improve efficiency of hashes deserialization

### DIFF
--- a/src/main/java/org/cyclonedx/util/deserializer/HashesDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/HashesDeserializer.java
@@ -1,44 +1,129 @@
 package org.cyclonedx.util.deserializer;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.cyclonedx.model.Hash;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class HashesDeserializer
     extends JsonDeserializer<List<Hash>>
 {
   @Override
-  public List<Hash> deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-    JsonNode node = parser.getCodec().readTree(parser);
-    return parseHashes(node.has("hash") ? node.get("hash") : node);
+  public List<Hash> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    if (p.currentToken() == JsonToken.START_ARRAY) {
+      return readHashArray(p);
+    }
+    if (p.currentToken() == JsonToken.START_OBJECT) {
+      return readHashesElement(p);
+    }
+
+    return new ArrayList<>();
   }
 
-  private List<Hash> parseHashes(JsonNode node) {
-    if (node.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    ArrayNode nodes = DeserializerUtils.getArrayNode(node, null);
+  /**
+   * Reads hashes from a JSON array:
+   * <pre>{@code
+   *   [
+   *     { "alg": "...", "content": "..." },
+   *     { "alg": "...", "content": "..." }
+   *   ]
+   * }</pre>
+   */
+  private List<Hash> readHashArray(JsonParser p) throws IOException {
     List<Hash> hashes = new ArrayList<>();
 
-    for (JsonNode hashNode : nodes) {
-      hashes.add(parseHash(hashNode));
+    while (p.nextToken() != JsonToken.END_ARRAY) {
+      Hash hash = readHash(p);
+      if (hash != null) {
+        hashes.add(hash);
+      }
     }
+
     return hashes;
   }
 
-  private Hash parseHash(JsonNode node) {
-    String alg = node.has("alg") ? node.get("alg").asText() : null;
-    String value = node.has("content") ? node.get("content").asText() : node.has("") ? node.get("").asText() : null;
+  /**
+   * Reads hashes from an XML {@code <hashes>} element:
+   * <pre>{@code
+   *   <hashes>
+   *     <hash alg="...">...</hash>
+   *     <hash alg="...">...</hash>
+   *   </hashes>
+   * }</pre>
+   * <p>
+   * Note that a deserializer higher up the chain may have materialized the tree already,
+   * in which case the structure handed to this method looks like this:
+   * <pre>{@code
+   *   {
+   *     "hash": [
+   *       { "alg": "...", "": "..." },
+   *       { "alg": "...", "": "..." }
+   *     ]
+   *   }
+   * }</pre>
+   */
+  private List<Hash> readHashesElement(JsonParser p) throws IOException {
+    List<Hash> hashes = new ArrayList<>();
 
-    return new Hash(alg, value);
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      final String fieldName = p.currentName();
+      p.nextToken();
+
+      if (!"hash".equals(fieldName)) {
+        p.skipChildren();
+        continue;
+      }
+
+      if (p.currentToken() == JsonToken.START_ARRAY) {
+        hashes.addAll(readHashArray(p));
+      }
+      else {
+        Hash hash = readHash(p);
+        if (hash != null) {
+          hashes.add(hash);
+        }
+      }
+    }
+
+    return hashes;
+  }
+
+  private Hash readHash(JsonParser p) throws IOException {
+    if (p.currentToken() != JsonToken.START_OBJECT) {
+      p.skipChildren();
+      return null;
+    }
+
+    String algorithm = null;
+    String value = null;
+    boolean hasKnownField = false;
+
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      final String fieldName = p.currentName();
+      p.nextToken();
+      switch (fieldName) {
+        case "alg":
+          algorithm = p.getValueAsString();
+          break;
+        // NB: For XML, content is the element's text, which gets translated
+        // to a field with empty name.
+        case "content":
+        case "":
+          value = p.getValueAsString();
+          break;
+        default:
+          p.skipChildren();
+          continue;
+      }
+
+      hasKnownField = true;
+    }
+
+    return hasKnownField ? new Hash(algorithm, value) : null;
   }
 }

--- a/src/test/java/org/cyclonedx/util/deserializer/HashesDeserializerTest.java
+++ b/src/test/java/org/cyclonedx/util/deserializer/HashesDeserializerTest.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util.deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Hash;
+import org.cyclonedx.parsers.XmlParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HashesDeserializerTest {
+
+    @Test
+    void shouldDeserializeHashesFromJson() throws Exception {
+        List<Hash> hashes = parseJson(/* language=JSON */ """
+                {
+                  "hashes": [
+                    { "alg": "MD5", "content": "abc" },
+                    { "alg": "SHA-1", "content": "def" }
+                  ]
+                }
+                """);
+
+        assertThat(hashes).satisfiesExactly(
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("MD5");
+                    assertThat(hash.getValue()).isEqualTo("abc");
+                },
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
+                    assertThat(hash.getValue()).isEqualTo("def");
+                });
+    }
+
+    @Test
+    void shouldDeserializeHashesFromXml() throws Exception {
+        List<Hash> hashes = parseXml(/* language=XML */ """
+                <component>
+                  <hashes>
+                    <hash alg="MD5">abc</hash>
+                    <hash alg="SHA-1">def</hash>
+                  </hashes>
+                </component>
+                """);
+
+        assertThat(hashes).satisfiesExactly(
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("MD5");
+                    assertThat(hash.getValue()).isEqualTo("abc");
+                },
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
+                    assertThat(hash.getValue()).isEqualTo("def");
+                });
+    }
+
+    @Test
+    void shouldDeserializeHashesOfNestedXmlComponents() throws Exception {
+        Bom bom = new XmlParser().parse(/* language=XML */ """
+                <bom xmlns="http://cyclonedx.org/schema/bom/1.5">
+                <metadata>
+                  <tools>
+                    <components>
+                      <component type="application">
+                        <name>Awesome Tool</name>
+                        <version>9.1.2</version>
+                        <hashes>
+                          <hash alg="MD5">abc</hash>
+                          <hash alg="SHA-1">def</hash>
+                        </hashes>
+                      </component>
+                    </components>
+                  </tools>
+                </metadata>
+                </bom>
+                """.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(bom.getMetadata().getToolChoice().getComponents().get(0).getHashes()).satisfiesExactly(
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("MD5");
+                    assertThat(hash.getValue()).isEqualTo("abc");
+                },
+                hash -> {
+                    assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
+                    assertThat(hash.getValue()).isEqualTo("def");
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"hashes\":[{}]}",
+            "{\"hashes\":[null]}",
+            "{\"hashes\":[\"nonsense\"]}",
+            "{\"hashes\":[{\"unknownField\":123}]}"
+    })
+    void shouldNotEmitHashesWithoutAnyKnownFieldsFromJson(String json) throws Exception {
+        assertThat(parseJson(json)).isEmpty();
+    }
+
+    @Test
+    void shouldNotEmitHashesWithoutAnyKnownFieldsFromXml() throws Exception {
+        assertThat(parseXml("<component><hashes><hash/></hashes></component>")).isEmpty();
+    }
+
+    @Test
+    void shouldKeepHashesWithOnlySomeKnownFields() throws Exception {
+        assertThat(parseJson("{\"hashes\":[{\"alg\":\"MD5\"}]}")).satisfiesExactly(hash -> {
+            assertThat(hash.getAlgorithm()).isEqualTo("MD5");
+            assertThat(hash.getValue()).isNull();
+        });
+    }
+
+    private static List<Hash> parseJson(String json) throws Exception {
+        return new ObjectMapper().readValue(json, Component.class).getHashes();
+    }
+
+    private static List<Hash> parseXml(String xml) throws Exception {
+        return new XmlMapper().readValue(xml, Component.class).getHashes();
+    }
+}


### PR DESCRIPTION
Avoids deserialization overhead by not reading the incoming data into `JsonNode`s, which materializes the full tree just to discard it shortly after.

Instead, use Jackson's streaming API to efficiently read JSON and XML structures.

Same principle as #927 