### PR TITLE
Improve efficiency of attachment text deserialization

### DIFF
--- a/src/main/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializer.java
@@ -1,9 +1,8 @@
 package org.cyclonedx.util.deserializer;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import org.cyclonedx.model.AttachmentText;
 
@@ -20,39 +19,52 @@ public class AttachmentTextDeserializer extends StdDeserializer<AttachmentText> 
   }
 
   @Override
-  public AttachmentText deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-    ObjectCodec codec = parser.getCodec();
-    JsonNode node = codec.readTree(parser);
+  public AttachmentText deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    if (p.currentToken() != JsonToken.START_OBJECT) {
+      if (p.currentToken() != JsonToken.VALUE_STRING) {
+        return null;
+      }
+
+      AttachmentText attachmentText = new AttachmentText();
+      attachmentText.setText(p.getValueAsString());
+      return attachmentText;
+    }
 
     AttachmentText attachmentText = new AttachmentText();
+    boolean hasKnownField = false;
 
-    JsonNode contentNode = node.get("content");
-    if (contentNode != null) {
-      attachmentText.setText(contentNode.asText());
-    } else if (node.has("")) {
-      attachmentText.setText(node.get("").asText());
-    } else if (node.isTextual()) {
-      attachmentText.setText(node.textValue());
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      final String fieldName = p.currentName();
+      p.nextToken();
+      switch (fieldName) {
+        // NB: For XML, content is the element's text, which gets translated
+        // to a field with empty name.
+        case "content":
+        case "":
+          attachmentText.setText(p.getValueAsString());
+          break;
+        // "content-type" for XML, "contentType" for JSON.
+        case "content-type":
+        case "contentType":
+          if (p.currentToken() != JsonToken.VALUE_STRING) {
+            continue;
+          }
+          attachmentText.setContentType(p.getValueAsString());
+          break;
+        case "encoding":
+          if (p.currentToken() != JsonToken.VALUE_STRING) {
+            continue;
+          }
+          attachmentText.setEncoding(p.getValueAsString());
+          break;
+        default:
+          p.skipChildren();
+          continue;
+      }
+
+      hasKnownField = true;
     }
 
-    JsonNode contentTypeNode = getContentTypeNode(node);
-    if (contentTypeNode != null && contentTypeNode.isTextual()) {
-      attachmentText.setContentType(contentTypeNode.asText());
-    }
-
-    JsonNode encodingNode = node.get("encoding");
-    if (encodingNode != null && encodingNode.isTextual()) {
-      attachmentText.setEncoding(encodingNode.asText());
-    }
-
-    return attachmentText;
-  }
-
-  private JsonNode getContentTypeNode(JsonNode node) {
-    JsonNode contentTypeNode = node.get("content-type");
-    if (contentTypeNode == null || !contentTypeNode.isTextual()) {
-      contentTypeNode = node.get("contentType");
-    }
-    return contentTypeNode;
+    return hasKnownField ? attachmentText : null;
   }
 }

--- a/src/main/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializer.java
@@ -22,6 +22,7 @@ public class AttachmentTextDeserializer extends StdDeserializer<AttachmentText> 
   public AttachmentText deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     if (p.currentToken() != JsonToken.START_OBJECT) {
       if (p.currentToken() != JsonToken.VALUE_STRING) {
+        p.skipChildren();
         return null;
       }
 
@@ -33,9 +34,16 @@ public class AttachmentTextDeserializer extends StdDeserializer<AttachmentText> 
     AttachmentText attachmentText = new AttachmentText();
     boolean hasKnownField = false;
 
-    while (p.nextToken() != JsonToken.END_OBJECT) {
+    while (p.nextToken() == JsonToken.FIELD_NAME) {
       final String fieldName = p.currentName();
-      p.nextToken();
+      final JsonToken valueToken = p.nextToken();
+
+      // None of the known fields have structured values.
+      if (!valueToken.isScalarValue()) {
+        p.skipChildren();
+        continue;
+      }
+
       switch (fieldName) {
         // NB: For XML, content is the element's text, which gets translated
         // to a field with empty name.
@@ -58,7 +66,6 @@ public class AttachmentTextDeserializer extends StdDeserializer<AttachmentText> 
           attachmentText.setEncoding(p.getValueAsString());
           break;
         default:
-          p.skipChildren();
           continue;
       }
 

--- a/src/main/java/org/cyclonedx/util/deserializer/DependencyDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/DependencyDeserializer.java
@@ -49,7 +49,7 @@ public class DependencyDeserializer extends StdDeserializer<List<Dependency>>
         return dependencies[0].getDependencies();
       }
     } else {
-      return Arrays.asList(dependencies.clone());
+      return Arrays.asList(dependencies);
     }
 
     return null;

--- a/src/main/java/org/cyclonedx/util/deserializer/ExternalReferencesDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/ExternalReferencesDeserializer.java
@@ -91,7 +91,7 @@ public class ExternalReferencesDeserializer extends JsonDeserializer<List<Extern
             throws IOException {
         List<ExternalReference> references = new ArrayList<>();
 
-        while (p.nextToken() != JsonToken.END_OBJECT) {
+        while (p.nextToken() == JsonToken.FIELD_NAME) {
             final String fieldName = p.currentName();
             p.nextToken();
 
@@ -122,9 +122,17 @@ public class ExternalReferencesDeserializer extends JsonDeserializer<List<Extern
         ExternalReference reference = new ExternalReference();
         boolean hasKnownField = false;
 
-        while (p.nextToken() != JsonToken.END_OBJECT) {
+        while (p.nextToken() == JsonToken.FIELD_NAME) {
             final String fieldName = p.currentName();
-            p.nextToken();
+            final JsonToken valueToken = p.nextToken();
+
+            // Only "hashes" and "properties" have structured values.
+            if (!valueToken.isScalarValue()
+                    && !"hashes".equals(fieldName)
+                    && !"properties".equals(fieldName)) {
+                p.skipChildren();
+                continue;
+            }
 
             switch (fieldName) {
                 case "url":
@@ -143,7 +151,6 @@ public class ExternalReferencesDeserializer extends JsonDeserializer<List<Extern
                     reference.setProperties(propertiesDeserializer.deserialize(p, ctxt));
                     break;
                 default:
-                    p.skipChildren();
                     continue;
             }
 

--- a/src/main/java/org/cyclonedx/util/deserializer/HashesDeserializer.java
+++ b/src/main/java/org/cyclonedx/util/deserializer/HashesDeserializer.java
@@ -70,7 +70,7 @@ public class HashesDeserializer
   private List<Hash> readHashesElement(JsonParser p) throws IOException {
     List<Hash> hashes = new ArrayList<>();
 
-    while (p.nextToken() != JsonToken.END_OBJECT) {
+    while (p.nextToken() == JsonToken.FIELD_NAME) {
       final String fieldName = p.currentName();
       p.nextToken();
 
@@ -103,9 +103,16 @@ public class HashesDeserializer
     String value = null;
     boolean hasKnownField = false;
 
-    while (p.nextToken() != JsonToken.END_OBJECT) {
+    while (p.nextToken() == JsonToken.FIELD_NAME) {
       final String fieldName = p.currentName();
-      p.nextToken();
+      final JsonToken valueToken = p.nextToken();
+
+      // None of the known fields have structured values.
+      if (!valueToken.isScalarValue()) {
+        p.skipChildren();
+        continue;
+      }
+
       switch (fieldName) {
         case "alg":
           algorithm = p.getValueAsString();
@@ -117,7 +124,6 @@ public class HashesDeserializer
           value = p.getValueAsString();
           break;
         default:
-          p.skipChildren();
           continue;
       }
 

--- a/src/test/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializerTest.java
+++ b/src/test/java/org/cyclonedx/util/deserializer/AttachmentTextDeserializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of CycloneDX Core (Java).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.util.deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.License;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttachmentTextDeserializerTest {
+
+    @Test
+    void shouldSkipUnknownFields() throws Exception {
+        final License license = parseLicense(/* language=JSON */ """
+                {
+                  "licenses": [
+                    {
+                      "license": {
+                        "name": "Custom",
+                        "text": {
+                          "contentType": "text/plain",
+                          "unknownField": { "nested": [ 1, 2, 3 ] },
+                          "encoding": "base64",
+                          "content": "abc"
+                        },
+                        "url": "https://example.com"
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        assertThat(license.getAttachmentText().getContentType()).isEqualTo("text/plain");
+        assertThat(license.getAttachmentText().getEncoding()).isEqualTo("base64");
+        assertThat(license.getAttachmentText().getText()).isEqualTo("abc");
+        assertThat(license.getUrl()).isEqualTo("https://example.com");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"licenses\":[{\"license\":{\"name\":\"C\",\"text\":{}}}]}",
+            "{\"licenses\":[{\"license\":{\"name\":\"C\",\"text\":{\"unknownField\":123}}}]}",
+            "{\"licenses\":[{\"license\":{\"name\":\"C\",\"text\":123}}]}"
+    })
+    void shouldNotEmitAttachmentTextWithoutAnyKnownFields(String json) throws Exception {
+        assertThat(parseLicense(json).getAttachmentText()).isNull();
+    }
+
+    @Test
+    void shouldEmitAttachmentTextForEmptyXmlElement() throws Exception {
+        final License license = parseXmlLicense(/* language=XML */ """
+                <component>
+                  <licenses>
+                    <license>
+                      <name>C</name>
+                      <text/>
+                    </license>
+                  </licenses>
+                </component>
+                """);
+
+        assertThat(license.getAttachmentText()).isNotNull();
+        assertThat(license.getAttachmentText().getText()).isEmpty();
+    }
+
+    private static License parseLicense(String json) throws Exception {
+        return new ObjectMapper().readValue(json, Component.class).getLicenses().getLicenses().get(0);
+    }
+
+    private static License parseXmlLicense(String xml) throws Exception {
+        return new XmlMapper().readValue(xml, Component.class).getLicenses().getLicenses().get(0);
+    }
+}

--- a/src/test/java/org/cyclonedx/util/deserializer/HashesDeserializerTest.java
+++ b/src/test/java/org/cyclonedx/util/deserializer/HashesDeserializerTest.java
@@ -36,50 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HashesDeserializerTest {
 
     @Test
-    void shouldDeserializeHashesFromJson() throws Exception {
-        List<Hash> hashes = parseJson(/* language=JSON */ """
-                {
-                  "hashes": [
-                    { "alg": "MD5", "content": "abc" },
-                    { "alg": "SHA-1", "content": "def" }
-                  ]
-                }
-                """);
-
-        assertThat(hashes).satisfiesExactly(
-                hash -> {
-                    assertThat(hash.getAlgorithm()).isEqualTo("MD5");
-                    assertThat(hash.getValue()).isEqualTo("abc");
-                },
-                hash -> {
-                    assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
-                    assertThat(hash.getValue()).isEqualTo("def");
-                });
-    }
-
-    @Test
-    void shouldDeserializeHashesFromXml() throws Exception {
-        List<Hash> hashes = parseXml(/* language=XML */ """
-                <component>
-                  <hashes>
-                    <hash alg="MD5">abc</hash>
-                    <hash alg="SHA-1">def</hash>
-                  </hashes>
-                </component>
-                """);
-
-        assertThat(hashes).satisfiesExactly(
-                hash -> {
-                    assertThat(hash.getAlgorithm()).isEqualTo("MD5");
-                    assertThat(hash.getValue()).isEqualTo("abc");
-                },
-                hash -> {
-                    assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
-                    assertThat(hash.getValue()).isEqualTo("def");
-                });
-    }
-
-    @Test
     void shouldDeserializeHashesOfNestedXmlComponents() throws Exception {
         Bom bom = new XmlParser().parse(/* language=XML */ """
                 <bom xmlns="http://cyclonedx.org/schema/bom/1.5">
@@ -90,8 +46,8 @@ class HashesDeserializerTest {
                         <name>Awesome Tool</name>
                         <version>9.1.2</version>
                         <hashes>
-                          <hash alg="MD5">abc</hash>
-                          <hash alg="SHA-1">def</hash>
+                          <hash alg="MD5">2342c2eaf1feb9a80195dbaddf2ebaa3</hash>
+                          <hash alg="SHA-1">68b78babe00a053f9e35ec6a2d9080f5b90122b0</hash>
                         </hashes>
                       </component>
                     </components>
@@ -103,11 +59,11 @@ class HashesDeserializerTest {
         assertThat(bom.getMetadata().getToolChoice().getComponents().get(0).getHashes()).satisfiesExactly(
                 hash -> {
                     assertThat(hash.getAlgorithm()).isEqualTo("MD5");
-                    assertThat(hash.getValue()).isEqualTo("abc");
+                    assertThat(hash.getValue()).isEqualTo("2342c2eaf1feb9a80195dbaddf2ebaa3");
                 },
                 hash -> {
                     assertThat(hash.getAlgorithm()).isEqualTo("SHA-1");
-                    assertThat(hash.getValue()).isEqualTo("def");
+                    assertThat(hash.getValue()).isEqualTo("68b78babe00a053f9e35ec6a2d9080f5b90122b0");
                 });
     }
 


### PR DESCRIPTION
Avoids deserialization overhead by not reading the incoming data into `JsonNodes`, which materializes the full tree just to discard it shortly after.

The main cost driver here was that attachment text usually contains large strings, and the redundant deserialization caused those strings to be cloned. The larger the strings, the higher the overhead.

Same principle as #927 and #928 