### PR TITLE
Reuse ObjectMapper instances

### DIFF
--- a/src/main/java/org/cyclonedx/parsers/JsonParser.java
+++ b/src/main/java/org/cyclonedx/parsers/JsonParser.java
@@ -43,18 +43,14 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class JsonParser extends CycloneDxSchema implements Parser {
 
-    private final ObjectMapper mapper;
-
-    public JsonParser() {
-        mapper = new ObjectMapper();
-    }
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * {@inheritDoc}
      */
     public Bom parse(final File file) throws ParseException {
         try {
-            return mapper.readValue(file, Bom.class);
+            return MAPPER.readValue(file, Bom.class);
         } catch (IOException e) {
             throw new ParseException("Unable to parse BOM from File", e);
         }
@@ -65,7 +61,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      */
     public Bom parse(final byte[] bomBytes) throws ParseException {
         try {
-            return mapper.readValue(bomBytes, Bom.class);
+            return MAPPER.readValue(bomBytes, Bom.class);
         } catch (RuntimeException | IOException e) {
             throw new ParseException("Unable to parse BOM from byte array", e);
         }
@@ -76,7 +72,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      */
     public Bom parse(final InputStream inputStream) throws ParseException {
         try {
-            return mapper.readValue(inputStream, Bom.class);
+            return MAPPER.readValue(inputStream, Bom.class);
         } catch (IOException e) {
             throw new ParseException("Unable to parse BOM from InputStream", e);
         }
@@ -87,7 +83,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      */
     public Bom parse(final Reader reader) throws ParseException {
         try {
-            return mapper.readValue(reader, Bom.class);
+            return MAPPER.readValue(reader, Bom.class);
         } catch (IOException e) {
             throw new ParseException("Unable to parse BOM from Reader", e);
         }
@@ -104,7 +100,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final File file, final Version schemaVersion) throws IOException {
-        return validate(mapper.readTree(file), schemaVersion);
+        return validate(MAPPER.readTree(file), schemaVersion);
     }
 
     /**
@@ -118,7 +114,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final byte[] bomBytes, final Version schemaVersion) throws IOException {
-        return validate(mapper.readTree(bomBytes), schemaVersion);
+        return validate(MAPPER.readTree(bomBytes), schemaVersion);
     }
 
     /**
@@ -139,7 +135,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
         if (firstChar != -1 && firstChar != '\uFEFF') {
             pushbackReader.unread(firstChar);
         }
-        return validate(mapper.readTree(pushbackReader), schemaVersion);
+        return validate(MAPPER.readTree(pushbackReader), schemaVersion);
     }
 
     /**
@@ -153,7 +149,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * {@inheritDoc}
      */
     public List<ParseException> validate(final InputStream inputStream, final Version schemaVersion) throws IOException {
-        return validate(mapper.readTree(inputStream), schemaVersion);
+        return validate(MAPPER.readTree(inputStream), schemaVersion);
     }
 
     /**
@@ -165,7 +161,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
      * @return a list of exceptions encountered during validation
      */
     public List<ParseException> validate(final String bomString, final Version schemaVersion) throws IOException {
-        return validate(mapper.readTree(skipUtf8Bom(bomString)), schemaVersion);
+        return validate(MAPPER.readTree(skipUtf8Bom(bomString)), schemaVersion);
     }
 
     /**
@@ -186,7 +182,7 @@ public class JsonParser extends CycloneDxSchema implements Parser {
             );
         }
 
-        List<Error> errors = getJsonSchema(schemaVersion, mapper).validate(mapper.readTree(bomJson.toString()));
+        List<Error> errors = getJsonSchema(schemaVersion, MAPPER).validate(MAPPER.readTree(bomJson.toString()));
         for (Error error : errors) {
             final boolean hasLocation =
                     error.getInstanceLocation() != null

--- a/src/main/java/org/cyclonedx/parsers/XmlParser.java
+++ b/src/main/java/org/cyclonedx/parsers/XmlParser.java
@@ -63,11 +63,7 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class XmlParser extends CycloneDxSchema implements Parser {
 
-    private final ObjectMapper mapper;
-
-    public XmlParser() {
-        mapper = new XmlMapper();
-    }
+    private static final ObjectMapper MAPPER = new XmlMapper();
 
     private static final Map<String, String> SCHEMA_VERSION_BY_NAMESPACE = new HashMap<>();
 
@@ -87,7 +83,7 @@ public class XmlParser extends CycloneDxSchema implements Parser {
                 schemaVersion = identifySchemaVersion(fis);
             }
 
-            return injectSchemaVersion(mapper.readValue(file, Bom.class), schemaVersion);
+            return injectSchemaVersion(MAPPER.readValue(file, Bom.class), schemaVersion);
         } catch (IOException | XMLStreamException e) {
             throw new ParseException(e);
         }
@@ -100,7 +96,7 @@ public class XmlParser extends CycloneDxSchema implements Parser {
         try {
             final String schemaVersion = identifySchemaVersion(new ByteArrayInputStream(bomBytes));
 
-            return injectSchemaVersion(mapper.readValue(bomBytes, Bom.class), schemaVersion);
+            return injectSchemaVersion(MAPPER.readValue(bomBytes, Bom.class), schemaVersion);
         } catch (IOException | XMLStreamException e) {
             throw new ParseException(e);
         }
@@ -111,7 +107,7 @@ public class XmlParser extends CycloneDxSchema implements Parser {
      */
     public Bom parse(final InputStream inputStream) throws ParseException {
         try {
-            return mapper.readValue(inputStream, Bom.class);
+            return MAPPER.readValue(inputStream, Bom.class);
         } catch (IOException e) {
             throw new ParseException(e);
         }
@@ -122,7 +118,7 @@ public class XmlParser extends CycloneDxSchema implements Parser {
      */
     public Bom parse(final Reader reader) throws ParseException {
         try {
-            return mapper.readValue(reader, Bom.class);
+            return MAPPER.readValue(reader, Bom.class);
         } catch (IOException e) {
             throw new ParseException(e);
         }


### PR DESCRIPTION
Parsers previously created new `ObjectMapper` instances for every new parser instance. `BomParserFactory#createParser` (the main entrypoint for parsing) creates new parser instances on each invocation.

Library consumers that parse many BOMs at high volume kept paying the price for Jackson re-initializing its `ObjectMapper`. Because it wasn't reused, its internal caching strategies for reflective lookups etc. could never take effect.

Jackson specifically recommends reusing `ObjectMapper`s: https://github.com/fasterxml/jackson-docs/wiki/presentation:-jackson-performance#basics-things-you-should-do-anyway